### PR TITLE
chore: add fixed admin user in default seed

### DIFF
--- a/database/factories/user_factory.ts
+++ b/database/factories/user_factory.ts
@@ -10,19 +10,7 @@ export const UserFactory = factory
       approved: faker.datatype.boolean(),
     }
   })
-  .build()
-
-/**
- * Define an admin user with fixed credentials.
- * This user starts approved.
- */
-export const AdminUserFactory = factory
-  .define(User, async () => {
-    return {
-      email: 'admin@relaxe.local',
-      password: '1234',
-      motivation: 'ADMIN',
-      approved: true,
-    }
+  .state('approved', (user) => {
+    user.approved = true
   })
   .build()

--- a/database/seeders/local_seeder.ts
+++ b/database/seeders/local_seeder.ts
@@ -1,6 +1,6 @@
 import { CollectifFactory } from '#database/factories/collectif_factory'
 import { ProcedureFactory } from '#database/factories/procedure_factory'
-import { AdminUserFactory, UserFactory } from '#database/factories/user_factory'
+import { UserFactory } from '#database/factories/user_factory'
 import { VilleFactory } from '#database/factories/ville_factory'
 import { BaseSeeder } from '@adonisjs/lucid/seeders'
 import { randomInt } from 'node:crypto'
@@ -19,6 +19,11 @@ export default class extends BaseSeeder {
       .createMany(50)
 
     await UserFactory.createMany(4)
-    await AdminUserFactory.create()
+    await UserFactory.apply('approved')
+      .merge({
+        email: 'admin@relaxe.local',
+        password: '1234',
+      })
+      .create()
   }
 }


### PR DESCRIPTION
Données test : 
- Ajout d'un utilisateur admin lors du seeding.
- Cet utilisateur a un email / mot de passe fixe pour garantir l'accès à un user admin approuvé par défaut