### PR TITLE
feat: Ajouter une page de détail pour les audiences (#39)

### DIFF
--- a/app/middleware/auth_middleware.ts
+++ b/app/middleware/auth_middleware.ts
@@ -1,6 +1,6 @@
+import type { Authenticators } from '@adonisjs/auth/types'
 import type { HttpContext } from '@adonisjs/core/http'
 import type { NextFn } from '@adonisjs/core/types/http'
-import type { Authenticators } from '@adonisjs/auth/types'
 
 /**
  * Auth middleware is used authenticate HTTP requests and deny

--- a/app/models/audience.ts
+++ b/app/models/audience.ts
@@ -46,7 +46,7 @@ export default class Audience extends BaseModel {
   declare decision_pour_les_infractions?: 'Condamnable' | 'Relaxe'
 
   @column()
-  declare numero_de_chambre?: number
+  declare numero_de_chambre?: string
 
   @column()
   declare nombre_de_prevenu_es?: number

--- a/app/models/procedure.ts
+++ b/app/models/procedure.ts
@@ -1,11 +1,14 @@
-import { DateTime } from 'luxon'
 import { BaseModel, belongsTo, column, hasMany } from '@adonisjs/lucid/orm'
 import type { BelongsTo, HasMany } from '@adonisjs/lucid/types/relations'
+import { DateTime } from 'luxon'
 import Audience from './audience.js'
 import Collectif from './collectif.js'
 
 export default class Procedure extends BaseModel {
   @column({ isPrimary: true })
+  declare id: string
+
+  @column()
   declare nom: string
 
   @hasMany(() => Audience, {

--- a/database/factories/audience_factory.ts
+++ b/database/factories/audience_factory.ts
@@ -1,5 +1,5 @@
-import factory from '@adonisjs/lucid/factories'
 import Audience from '#models/audience'
+import factory from '@adonisjs/lucid/factories'
 import { DateTime } from 'luxon'
 import { VilleFactory } from './ville_factory.js'
 
@@ -16,7 +16,7 @@ export const AudienceFactory = factory
       date_de_decision: DateTime.fromJSDate(faker.date.past()),
       decision_pour_les_faits: faker.helpers.arrayElement(['Condamnable', 'Relaxe']),
       decision_pour_les_infractions: faker.helpers.arrayElement(['Condamnable', 'Relaxe']),
-      numero_de_chambre: faker.number.int({ min: 0, max: 10 }),
+      numero_de_chambre: `Tribunal de ${faker.location.city()} chambre correctionnelle n°${faker.number.int({ min: 0, max: 50 })}`,
       nombre_de_prevenu_es: faker.number.int({ min: 0, max: 10 }),
       nombre_de_temoins: faker.number.int({ min: 0, max: 10 }),
       expertise_des_temoins: faker.helpers

--- a/database/factories/collectif_factory.ts
+++ b/database/factories/collectif_factory.ts
@@ -1,10 +1,10 @@
-import factory from '@adonisjs/lucid/factories'
 import Collectif from '#models/collectif'
+import factory from '@adonisjs/lucid/factories'
 
 export const CollectifFactory = factory
   .define(Collectif, async ({ faker }) => {
     return {
-      nom: faker.word.words(3),
+      nom: faker.company.name(),
     }
   })
   .build()

--- a/database/factories/procedure_factory.ts
+++ b/database/factories/procedure_factory.ts
@@ -1,12 +1,12 @@
-import factory from '@adonisjs/lucid/factories'
 import Procedure from '#models/procedure'
+import factory from '@adonisjs/lucid/factories'
 import { DateTime } from 'luxon'
 import { AudienceFactory } from './audience_factory.js'
 
 export const ProcedureFactory = factory
   .define(Procedure, async ({ faker }) => {
     return {
-      nom: faker.string.alpha({ length: 80 }),
+      nom: faker.lorem.sentence(),
       date_des_faits: DateTime.fromJSDate(faker.date.past()),
       courte_description: faker.lorem.paragraph(),
       description: faker.lorem.paragraphs(),

--- a/resources/views/pages/audience.edge
+++ b/resources/views/pages/audience.edge
@@ -1,29 +1,231 @@
 <!DOCTYPE html>
 <html lang="en">
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>
-    Relaxes Pour Le Vivant
-  </title>
-  @include('partials/bootstrap')
-</head>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      Relaxes Pour Le Vivant
+    </title>
+    @include('partials/bootstrap')
+  </head>
 
-<body class="bg-light">
-  @include('partials/navbar')
-  <div class="container mt-3">
-    <h3>Date de l'audience</h3>
-    <p>{{ audience.date_de_l_audience.toLocaleString() }}</p>
-    <h3>Ville de l'audience</h3>
-    <p>{{ audience.ville_de_l_audience }}</p>
-    <h3>Juridiction</h3>
-    <p>{{ audience.juridiction }}</p>
-    <h3>Date de décision</h3>
-    <p>{{ audience.date_de_decision.toLocaleString() }}</p>
-    <h3>Decision pour les faits</h3>
-    <p>{{ audience.decision_pour_les_faits }}</p>
-    <h3>Decision pour les infractions</h3>
-    <p>{{ audience.decision_pour_les_infractions }}</p>
+  <body class="bg-light">
+    @include('partials/navbar')
+
+    <div class="container mt-3">
+      <div class="card">
+        <div class="card-body">
+          <header>
+            <h1>
+              {{ audience.procedure.nom }}<br />
+              <small class="text-body-secondary">{{ audience.procedure.courte_description }}</small>
+            </h1>
+          </header>
+
+          <section class="p-2 rounded text-bg-secondary mt-3" aria-labelledby="section-resume-jugement-heading">
+            <h3 id="section-resume-jugement-heading">
+              Résumé du jugement
+            </h3>
+            <p>
+              {{ audience.resume_du_jugement_ou_arret }}
+            </p>
+            <div class="d-flex gap-2 flex-wrap">
+              @if (audience.recit_d_audience)
+                <a href="{{ audience.recit_d_audience }}" class="badge text-bg-light" download>🔗 Récit d'audience</a>
+              @endif
+              <a href="{{ audience.decision }}" class="badge text-bg-light" download>🔗 Décision</a>
+            </div>
+          </section>
+
+          <section class="mt-3" aria-labelledby="section-infos-generales-heading">
+            <h3 id="section-infos-generales-heading">
+              Informations générales
+            </h3>
+            <dl class="row">
+              <dt class="col-sm-3">
+                Date de l'audience
+              </dt>
+              <dd class="col-sm-9">
+                {{ audience.date_de_l_audience.toLocaleString() }}
+              </dd>
+              <dt class="col-sm-3">
+                Ville de l'audience
+              </dt>
+              <dd class="col-sm-9">
+                {{ audience.ville_de_l_audience }}
+              </dd>
+              <dt class="col-sm-3">
+                Juridiction
+              </dt>
+              <dd class="col-sm-9">
+                {{ audience.juridiction }}
+              </dd>
+              @if (audience.numero_de_chambre)
+                <dt class="col-sm-3">
+                  Numéro de chambre
+                </dt>
+                <dd class="col-sm-9">
+                  {{ audience.numero_de_chambre }}
+                </dd>
+              @endif
+            </dl>
+          </section>
+
+          <section class="mt-3" aria-labelledby="section-defense-heading">
+            <h3 id="section-defense-heading">
+              Défense
+            </h3>
+            <dl class="row">
+              @if (audience.nombre_de_prevenu_es)
+                <dt class="col-sm-3">
+                  Nombre de prévenu·es
+                </dt>
+                <dd class="col-sm-9">
+                  {{ audience.nombre_de_prevenu_es }}
+                </dd>
+              @endif
+              @if (audience.nombre_de_temoins)
+                <dt class="col-sm-3">
+                  Nombre de témoins
+                </dt>
+                <dd class="col-sm-9">
+                  {{ audience.nombre_de_temoins }}
+                </dd>
+              @endif
+            </dl>
+          </section>
+
+          <section class="mt-3" aria-labelledby="section-accusation-heading">
+            <h3 id="section-accusation-heading">
+              Accusation
+            </h3>
+            <dl class="row">
+              @if (audience.nombre_d_avocat_es)
+                <dt class="col-sm-3">
+                  Nombre d'avocat·es
+                </dt>
+                <dd class="col-sm-9">
+                  {{ audience.nombre_d_avocat_es }}
+                </dd>
+              @endif
+              @if (audience.nom_des_parties_civiles)
+                <dt class="col-sm-3">
+                  Nom des parties civiles
+                </dt>
+                <dd class="col-sm-9">
+                  {{ audience.nom_des_parties_civiles }}
+                </dd>
+              @endif
+              @if (audience.demande_des_parties_civiles)
+                <dt class="col-sm-3">
+                  Demande des parties civiles
+                </dt>
+                <dd class="col-sm-9">
+                  {{ audience.demande_des_parties_civiles }}
+                </dd>
+              @endif
+            </dl>
+          </section>
+
+          <section class="mt-3" aria-labelledby="section-jugement-heading">
+            <h3 id="section-jugement-heading">
+              Jugement
+            </h3>
+            <dl class="row">
+              @if (audience.composition_du_tribunal)
+                <dt class="col-sm-3">
+                  Composition du Tribunal
+                </dt>
+                <dd class="col-sm-9">
+                  {{ audience.composition_du_tribunal }}
+                </dd>
+              @endif
+            </dl>
+          </section>
+
+          <section class="mt-3" aria-labelledby="section-decision-heading">
+            <h3 id="section-decision-heading">
+              Décision
+            </h3>
+            <dl class="row">
+              <dt class="col-sm-3">
+                Date de décision
+              </dt>
+              <dd class="col-sm-9">
+                {{ audience.date_de_decision.toLocaleString() }}
+              </dd>
+              @if (audience.fondement_de_la_relaxe)
+                <dt class="col-sm-3">
+                  Fondement de la relaxe
+                </dt>
+                <dd class="col-sm-9">
+                  {{ audience.fondement_de_la_relaxe }}
+                </dd>
+              @endif
+              <dt class="col-sm-3">
+                Decision pour les faits
+              </dt>
+              <dd class="col-sm-9">
+                {{ audience.decision_pour_les_faits }}
+              </dd>
+              @if (audience.decision_pour_les_infractions)
+                <dt class="col-sm-3">
+                  Decision pour les infractions
+                </dt>
+                <dd class="col-sm-9">
+                  {{ audience.decision_pour_les_infractions }}
+                </dd>
+              @endif
+              <dt class="col-sm-3">
+                Peine pour les faits
+              </dt>
+              <dd class="col-sm-9">
+                {{ audience.peine_pour_les_faits }}
+              </dd>
+              @if (audience.peine_complementaire)
+                <dt class="col-sm-3">
+                  Peine complémentaire
+                </dt>
+                <dd class="col-sm-9">
+                  {{ audience.peine_complementaire }}
+                </dd>
+              @endif
+            </dl>
+          </section>
+
+          <section class="mt-3" aria-labelledby="section-appel-heading">
+            <h3 id="section-appel-heading">
+              Appel
+            </h3>
+            <dl class="row">
+              <dt class="col-sm-3">
+                Appel d'une des parties
+              </dt>
+              <dd class="col-sm-9">
+                {{ audience.appel_d_une_des_parties ? 'Oui' : 'Non' }}
+              </dd>
+              @if (audience.partie_de_l_appel_principal)
+                <dt class="col-sm-3">
+                  Partie de l'appel principal
+                </dt>
+                <dd class="col-sm-9">
+                  {{ audience.partie_de_l_appel_principal }}
+                </dd>
+              @endif
+              @if (audience.partie_de_l_appel_incident)
+                <dt class="col-sm-3">
+                  Partie de l'appel incident
+                </dt>
+                <dd class="col-sm-9">
+                  {{ audience.partie_de_l_appel_incident }}
+                </dd>
+              @endif
+            </dl>
+          </section>
+        </div>
+      </div>
+    </div>
   </div>
 </body>
+</html>

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -15,7 +15,7 @@ const audiencesController = () => import('#controllers/audiences_controller')
 
 router.on('/welcome').render('pages/welcome').use(middleware.guest())
 router.get('/audiences', [HomeController, 'home']).use(middleware.auth())
-router.get('/audiences/:id', [audiencesController, 'get'])
+router.get('/audiences/:id', [audiencesController, 'get']).use(middleware.auth())
 router.on('/sign-up').render('pages/auth/sign_up')
 router.on('/sign-in').render('pages/auth/sign_in').use(middleware.guest())
 


### PR DESCRIPTION
# Issue #39 - Ajouter une page de détail pour les audiences

## Description
- La page est protégée et redirige vers le login/le formulaire de demande (discussion en cours) si pas authentifié
  - La redirection vers l'audience en suivant l'authentification sera fait sur un autre ticket
- Ajout des informations existantes en base telles que décrites sur le [figma](https://www.figma.com/design/ppeLggdUTyB9p5qXNT1C59/MSDE---D4G?node-id=5-1782&t=CKmWafHCuGfch9Ha-4)
  - Les informations qui ne sont pas marquées comme "required" auront leur section d'affichée seulement si une valeur est présente (on evite d'afficher la section si elle est vide)
- Le style utilise des classes simple de bootstrap sans aller trop loin dans la customisation en attendant le design system
- `numero_de_chambre` a été transformé en string pour correspondre au data model. La factory a été mise à jour pour une valeur plus proche du réél.
- La factory pour Procedure utilise `faker.lorem.sentence` pour le nom plutôt qu'une string alphanum car ce champ est affiché sur la page de détail en tant que titre.
- La factory pour Collectif utilise `faker.company.name` plutôt qu'une suite de mots en lowercase
- ajout d'un id technique à la table Procedure (à débattre si on change la relation sur le nom avec une audience)

## Données non reprise de la maquette : 
- badges de tags (inexistant dans le modèle)
- chefs de prévention (relation et définition du modèle à faire)
- Réquisitions (inexistant dans le modèle)
- référence de la décision (inexistant dans le modèle)
- onglets "Procédure, Tribunal, Cour d'appel, Cour de cassation" (en cours de discussion)
- Dommages et intérêts (inexistant dans le modèle)
- Inscription au casier (inexistant dans le modèle)
    
## Donnée oubliée sur la maquette mais ajouté ici : 
- decision_pour_les_infractions

## Questions restantes : 
- Actuellement une procédure est lié à une audience par son nom qui est aussi sa clé primaire. Cela ne me semble pas assez déterminant comme clé primaire. Je rajouterai plutôt un id technique.
- Pour le chef de prévention, il faudra séparer le nom et le numéro d'article pour pouvoir appliquer des styles différents sur l'interface
- `plaidoirie_de_la_defense` est défini comme string mais une liste sur le document data model
- intégration d'icone via EdgeJS ? https://edgejs.dev/docs/edge-iconify ou une autre lib  ou custom via le Design system ?
- utilisation de l'internationalisation pour mettre l'application en FR https://docs.adonisjs.com/guides/digging-deeper/i18n#internationalization-and-localization, notamment format de date.

