### PR TITLE
feat: gestion publication audience et procedure

### DIFF
--- a/app/controllers/audiences_controller.ts
+++ b/app/controllers/audiences_controller.ts
@@ -2,9 +2,18 @@ import Audience from '#models/audience'
 import type { HttpContext } from '@adonisjs/core/http'
 
 export default class AudiencesController {
+  /**
+   * Returns the page for an audience if both audience and its procedure are published.
+   * @param HttpContext
+   * @returns
+   */
   async get({ request, view }: HttpContext) {
     const audience = await Audience.query()
       .where('id', request.param('id'))
+      .andWhere('publiee', true)
+      .andWhereHas('procedure', (query) => {
+        query.where('publiee', true)
+      })
       .preload('procedure')
       .firstOrFail()
 

--- a/app/models/audience.ts
+++ b/app/models/audience.ts
@@ -1,7 +1,7 @@
-import { DateTime } from 'luxon'
 import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
-import Procedure from './procedure.js'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import { DateTime } from 'luxon'
+import Procedure from './procedure.js'
 import Ville from './ville.js'
 
 export default class Audience extends BaseModel {
@@ -107,4 +107,7 @@ export default class Audience extends BaseModel {
 
   @column()
   declare resume_du_jugement_ou_arret?: string
+
+  @column()
+  declare publiee: boolean
 }

--- a/app/models/procedure.ts
+++ b/app/models/procedure.ts
@@ -46,4 +46,7 @@ export default class Procedure extends BaseModel {
 
   @column()
   declare collectif_d_action_ou_lutte: string
+
+  @column()
+  declare publiee: boolean
 }

--- a/database/factories/audience_factory.ts
+++ b/database/factories/audience_factory.ts
@@ -50,7 +50,14 @@ export const AudienceFactory = factory
       recit_d_audience: faker.system.filePath(),
       decision: faker.system.filePath(),
       resume_du_jugement_ou_arret: faker.lorem.paragraph(),
+      publiee: faker.datatype.boolean(),
     }
+  })
+  .state('publiee', (user) => {
+    user.publiee = true
+  })
+  .state('draft', (user) => {
+    user.publiee = false
   })
   .relation('ville', () => VilleFactory)
   .build()

--- a/database/factories/procedure_factory.ts
+++ b/database/factories/procedure_factory.ts
@@ -13,7 +13,14 @@ export const ProcedureFactory = factory
       poursuites: faker.lorem.words(),
       nom_des_parties_civiles: faker.word.words(3),
       la_presse_parle_des_faits: faker.internet.url(),
+      publiee: faker.datatype.boolean(),
     }
+  })
+  .state('publiee', (user) => {
+    user.publiee = true
+  })
+  .state('draft', (user) => {
+    user.publiee = false
   })
   .relation('audiences', () => AudienceFactory)
   .build()

--- a/resources/views/pages/audience.edge
+++ b/resources/views/pages/audience.edge
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
 
   <head>
     <meta charset="utf-8" />
@@ -27,7 +27,8 @@
             <h3 id="section-resume-jugement-heading">
               Résumé du jugement
             </h3>
-            <p>
+            {{-- TODO: remove text-body-secondary when design system is fixed (i.e: no color on p element) --}}
+            <p class="text-body-secondary">
               {{ audience.resume_du_jugement_ou_arret }}
             </p>
             <div class="d-flex gap-2 flex-wrap">

--- a/resources/views/pages/errors/not_found.edge
+++ b/resources/views/pages/errors/not_found.edge
@@ -1,8 +1,24 @@
-<h1>
-  404 - Page not found
-</h1>
-<p>
-  This template is rendered by the
-  <a href="http://docs.adonisjs.com/guides/exception-handling#status-pages">status pages feature</a>
-  of the global exception handler.
-</p>
+<!DOCTYPE html>
+<html lang="fr">
+
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      Relaxes Pour Le Vivant
+    </title>
+    @include('partials/bootstrap')
+  </head>
+
+  <body class="bg-light">
+    @include('partials/navbar')
+
+    <div class="container mt-3">
+      <h1>
+        404 - Page non trouvée
+      </h1>
+    </div>
+
+  </body>
+
+</html>

--- a/resources/views/pages/errors/server_error.edge
+++ b/resources/views/pages/errors/server_error.edge
@@ -1,8 +1,24 @@
-<h1>
-  {{ error.code }} - Server error
-</h1>
-<p>
-  This template is rendered by the
-  <a href="http://docs.adonisjs.com/guides/exception-handling#status-pages">status pages feature</a>
-  of the global exception handler.
-</p>
+<!DOCTYPE html>
+<html lang="fr">
+
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      Relaxes Pour Le Vivant
+    </title>
+    @include('partials/bootstrap')
+  </head>
+
+  <body class="bg-light">
+    @include('partials/navbar')
+
+    <div class="container mt-3">
+      <h1>
+        {{ error.code }} - Erreur serveur
+      </h1>
+    </div>
+
+  </body>
+
+</html>

--- a/resources/views/pages/home.edge
+++ b/resources/views/pages/home.edge
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
 
 <head>
   <meta charset="utf-8" />


### PR DESCRIPTION
Issue #47 - Ajouter la publication d'une audience et d'une procedure

- Ajout des propriétés `publiee` sur le modèle Audience et Procedure
   - Ajout de state aux factory associées pour cette propriété
- Le endpoint `/audiences/:id` ne retourne plus que les audiences publiee et dont la procedure est publiée également
- Mise à jour des templates d'erreur affichés par l'appli
  - not_found lorsqu'une requete en bdd ne trouve pas de ligne comme ici
  - server_error pour tout autre probleme non géré

Note : Pour voir les erreurs en dev il faut passer en mode production ou modifier la ligne `protected renderStatusPages = app.inProduction` du fichier `exceptions/handler.ts`

Fix : 
- Utilisation de la langue FR sur la balise html