### PR TITLE
removing svg asset from forgotten password email template

### DIFF
--- a/resources/views/emails/forgotten_password.edge
+++ b/resources/views/emails/forgotten_password.edge
@@ -13,11 +13,6 @@
       <td align="center">
         <table width="600" cellpadding="0" cellspacing="8px" border="0">
           <tr>
-            <td align="center">
-              <img src="https://msde-association.org/wp-content/uploads/2025/07/LOGOTYPE_X2.png" />
-            </td>
-          </tr>
-          <tr>
             <td>
               <h1>
                 Demande de mot de passe oublié


### PR DESCRIPTION
Suite aux revirements ([commentaires issus de la précédente PR merged](https://github.com/dataforgoodfr/14_RelaxesPourLeVivant/pull/74#issuecomment-3966441553)), plutôt que de laisser l'asset du logo de la MSDE chargé depuis un site en dehors de cette codebase et faire un ticket à ce sujet, et sachant que les décisions sur les workflows par e-mail n'ont pas encore été discutées, qu'il n'existe pas de maquette encore et que nous ne sommes pas sûrs de l'implémentation de l'infra en prod, je propose plutôt de supprimer l'asset du template de l'e-mail.
Nous l'ajouterons en fonction des demandes lorsque le sujet sera abordé par le design.
Désolé pour la double request!