### PR TITLE
feat: gestion des webhooks nocodb #107

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 TZ=UTC
 PORT=3333
 HOST=localhost
+SERVER_URL=localhost
 LOG_LEVEL=info
 APP_KEY=
 NODE_ENV=development
@@ -24,6 +25,7 @@ NC_API_TOKEN=generated-token
 NC_API_URL=http://localhost:3333
 NC_ATTACHMENT_FIELD_SIZE=20971520  # default = 20 MB
 NC_SECURE_ATTACHMENTS=true
+NC_ALLOW_LOCAL_HOOKS=true
 
 # METABASE
 MB_DB_TYPE=postgres

--- a/app/controllers/webhooks_controller.ts
+++ b/app/controllers/webhooks_controller.ts
@@ -1,0 +1,15 @@
+import type { HttpContext } from '@adonisjs/core/http'
+
+export default class WebhooksController {
+  async user({ request, response }: HttpContext) {
+    console.log(
+      'Received webhook with event name:',
+      request.header('X-Event-Name'),
+      'and payload:',
+      request.body()
+    )
+    if (!request.header('X-Event-Name')) {
+      return response.badRequest({ error: 'Missing X-Event-Name header' })
+    }
+  }
+}

--- a/app/middleware/webhook_middleware.ts
+++ b/app/middleware/webhook_middleware.ts
@@ -1,0 +1,15 @@
+import env from '#start/env'
+import type { HttpContext } from '@adonisjs/core/http'
+import type { NextFn } from '@adonisjs/core/types/http'
+
+export default class WebhookMiddleware {
+  private readonly apiToken = env.get('NC_API_TOKEN')
+
+  async handle(ctx: HttpContext, next: NextFn) {
+    if (ctx.request.header('Authorization') !== `Bearer ${this.apiToken}`) {
+      return ctx.response.unauthorized({ error: 'Invalid API token' })
+    }
+
+    await next()
+  }
+}

--- a/config/shield.ts
+++ b/config/shield.ts
@@ -17,7 +17,9 @@ const shieldConfig = defineConfig({
    */
   csrf: {
     enabled: true,
-    exceptRoutes: [],
+    exceptRoutes: (ctx) => {
+      return ctx.request.url().startsWith('/_/')
+    },
     enableXsrfCookie: false,
     methods: ['POST', 'PUT', 'PATCH', 'DELETE'],
   },

--- a/start/env.ts
+++ b/start/env.ts
@@ -17,6 +17,7 @@ export default await Env.create(new URL('../', import.meta.url), {
   APP_KEY: Env.schema.string(),
   HOST: Env.schema.string({ format: 'host' }),
   LOG_LEVEL: Env.schema.string(),
+  NC_API_TOKEN: Env.schema.string(),
 
   /*
   |----------------------------------------------------------

--- a/start/kernel.ts
+++ b/start/kernel.ts
@@ -46,4 +46,5 @@ router.use([
 export const middleware = router.named({
   guest: () => import('#middleware/guest_middleware'),
   auth: () => import('#middleware/auth_middleware'),
+  webhook: () => import('#middleware/webhook_middleware'),
 })

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -13,6 +13,7 @@ import { middleware } from './kernel.js'
 const HomeController = () => import('#controllers/home_controller')
 const AuthController = () => import('#controllers/auth_controller')
 const AudiencesController = () => import('#controllers/audiences_controller')
+const WebhooksController = () => import('#controllers/webhooks_controller')
 
 router.on('/welcome').render('pages/welcome').use(middleware.guest())
 router.get('/audiences', [HomeController, 'home']).use(middleware.auth())
@@ -37,6 +38,13 @@ router.post('/logout', [AuthController, 'signout'])
 router.post('/change-password', [AuthController, 'changePassword']).use(middleware.auth())
 router.post('/forgotten-password', [AuthController, 'forgottenPassword'])
 router.post('/reset-password', [AuthController, 'handleResetPassword'])
+
+router
+  .group(() => {
+    router.post('/user', [WebhooksController, 'user'])
+  })
+  .prefix('/_/webhooks')
+  .use(middleware.webhook())
 
 router.on('*').redirectToPath('/welcome')
 


### PR DESCRIPTION
Issue : #107 

- Ajout d'un groupe de route sous le préfixe `/_/webhooks` pour recevoir les webhooks nocodb liés aux différentes ressources.
- Pour la ressource `user`, on place une route POST `/_/webhooks/user` pour recevoir un évènement avec le header `X-Event-Name=user-approved`, s'il est absent on retourne une 400 Bad request.
- Création d'un middleware dédié pour vérifier la présence du header d'authorization (bearer utilisant NC_API_TOKEN). S'il est absent ou invalide on retourne unauthorized
- Comme sur l'import csv, exclusion des routes préfixées par `/_/` du shield csrf


Pour faire fonctionner, j'ai du définir la variable d'environnement `SERVER_URL` qui était définie dans `vite.config` pour `allowedHosts`. Cela est probablement du au fait que j'utilise un dev container et que je n'utilise donc pas localhost comme host, ce qui est autorisé par défaut par vite ([voir docs](https://vite.dev/config/server-options#server-allowedhosts)).