### PR TITLE
feat: recherche par chef prevention categories (#104)

### DIFF
--- a/app/controllers/home_controller.ts
+++ b/app/controllers/home_controller.ts
@@ -10,10 +10,11 @@ export default class HomeController {
   async home({ request, view }: HttpContext) {
     const searchQuery = await request.validateUsing(searchQueryValidator)
 
-    const [audiences, villes, collectifs] = await Promise.all([
+    const [audiences, villes, collectifs, chefDePreventionCategories] = await Promise.all([
       this.audienceService.searchAudiences(searchQuery),
       this.audienceService.getVilles(),
       this.audienceService.getCollectifs(),
+      this.audienceService.getChefDePreventionCategories(),
     ])
 
     const paginations = audiences.getUrlsForRange(1, audiences.lastPage).map((anchor) => {
@@ -28,6 +29,7 @@ export default class HomeController {
       audiences,
       paginations,
       searchQuery,
+      chefDePreventionCategories,
     })
   }
 }

--- a/app/services/audience_service.ts
+++ b/app/services/audience_service.ts
@@ -7,7 +7,7 @@ type SearchAudiencesQuery = {
   endDate?: string
   decision?: string
   juridiction?: string
-  chefDePrevention?: string
+  chefDePrevention?: string[]
   ville?: string
   collectif?: string[]
   page?: number
@@ -83,6 +83,10 @@ export class AudienceService {
       query.andWhere('audiences.ville_de_l_audience', searchQuery.ville)
     }
 
+    if (searchQuery.chefDePrevention) {
+      query.andWhereIn('audiences.chefs_de_prevention_categorie', searchQuery.chefDePrevention)
+    }
+
     if (searchQuery.collectif) {
       query.andWhereIn('procedures.collectif_d_action_ou_lutte', searchQuery.collectif)
     }
@@ -96,5 +100,9 @@ export class AudienceService {
 
   async getCollectifs(): Promise<Array<{ nom: string }>> {
     return db.query().select('*').from('collectifs')
+  }
+
+  async getChefDePreventionCategories(): Promise<Array<{ intitule: string }>> {
+    return db.query().select('*').from('chef_prevention_categories')
   }
 }

--- a/app/validators/search_query.ts
+++ b/app/validators/search_query.ts
@@ -7,7 +7,7 @@ export const searchQueryValidator = vine.compile(
     endDate: vine.string().optional(),
     decision: vine.string().optional(),
     juridiction: vine.string().optional(),
-    chefDePrevention: vine.string().optional(),
+    chefDePrevention: vine.array(vine.string()).optional(),
     ville: vine.string().optional(),
     collectif: vine.array(vine.string()).optional(),
     page: vine.number().optional(),

--- a/database/migrations/1773866930718_create_chef_prevention_categories_view.ts
+++ b/database/migrations/1773866930718_create_chef_prevention_categories_view.ts
@@ -1,0 +1,23 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'chef_prevention_categories'
+
+  async up() {
+    this.schema.createView(this.tableName, (view) => {
+      view.as(
+        this.db
+          .knexQuery()
+          .distinct(
+            this.db.knexRawQuery("string_to_table(chefs_de_prevention_categorie, ',') as intitule")
+          )
+          .from('audiences')
+          .orderBy('intitule')
+      )
+    })
+  }
+
+  async down() {
+    this.schema.dropView(this.tableName)
+  }
+}

--- a/resources/views/pages/home.edge
+++ b/resources/views/pages/home.edge
@@ -91,17 +91,16 @@
             </select>
           </div>
           <div class="col">
-            <select name="chefDePrevention" class="form-select">
-              <option value="" {{ searchQuery.chefDePrevention==="" ? "selected" : "" }}>
+            <select name="chefDePrevention[]" class="form-select" multiple>
+              <option value="" disabled>
                 Chef de prévention
               </option>
-              @each(chefDePrevention in [])
+              @each(chefDePrevention in chefDePreventionCategories)
                 <option
-                  value="{{ chefDePrevention.nom }}"
-                  {{ searchQuery.chefDePrevention===chefDePrevention.nom
-              ? "selected" : "" }}
+                  value="{{ chefDePrevention.intitule }}"
+                  {{ searchQuery.chefDePrevention?.includes(chefDePrevention.intitule) ? "selected" : "" }}
                 >
-                  {{ chefDePrevention.nom }}
+                  {{ chefDePrevention.intitule }}
                 </option>
               @end
             </select>
@@ -119,7 +118,7 @@
             </select>
           </div>
           <div class="col">
-            <select name="collectif" class="form-select" multiple>
+            <select name="collectif[]" class="form-select" multiple>
               <option value="" disabled>
                 Collectif d'action
               </option>


### PR DESCRIPTION
Issue : #104 

- Ajout des chefs de prevention - categorie seulement - sur la recherche
- Ajout d'une vue chef de prevention comme pour les collectifs et les villes
- Correction des multi-select lorsqu'on selectionne qu'une seule valeur (utilisation de la notation "tableau" sur le nom du champ de formulaire, e.g : `name=collectifs[]`). Cela permet au back de recevoir une liste dans tous les cas.