### PR TITLE
refactor(audiences): move timeline algo to mappers

### DIFF
--- a/app/controllers/home_controller.ts
+++ b/app/controllers/home_controller.ts
@@ -2,6 +2,7 @@ import { AudienceService } from '#services/audience_service'
 import { searchQueryValidator } from '#validators/search_query'
 import { inject } from '@adonisjs/core'
 import type { HttpContext } from '@adonisjs/core/http'
+import { TimelineDataMapper } from './mappers/timeline_mapper.js'
 
 @inject()
 export default class HomeController {
@@ -22,10 +23,15 @@ export default class HomeController {
       return { url: `?${url}`, page: anchor.page }
     })
 
+    const timelineDataMapper = new TimelineDataMapper()
+
     return view.render('pages/home', {
       villes,
       collectifs,
-      audiences,
+      audiences: audiences.map((audience) => {
+        audience.timeline = timelineDataMapper.map(audience)
+        return audience
+      }),
       paginations,
       searchQuery,
     })

--- a/app/controllers/mappers/timeline_mapper.ts
+++ b/app/controllers/mappers/timeline_mapper.ts
@@ -1,0 +1,65 @@
+type TimelineItem = {
+  id: number
+  date_de_decision?: string
+  degre_de_juridiction?: string
+  decision_pour_les_infractions_principales?: string
+  type_de_peine_pour_les_infractions_principales?: string
+}
+
+/**
+ * Filters out timeline for a given maximum number of events,
+ * and sorting it ascendant with a preferred position for current audience's date
+ */
+export class TimelineDataMapper {
+  constructor(
+    private readonly maximumNumberOfEvents = 4,
+    private readonly preferredPositionForCurrentAudience = 1
+  ) {}
+
+  map(audience: { timeline: TimelineItem[]; id: number }) {
+    const sortedTimeline = audience.timeline
+      .map<TimelineItem & { date_de_decision: string }>((event) => ({
+        ...event,
+        date_de_decision: event.date_de_decision ?? '2199-12-31',
+      }))
+      // Sorting dates (ASC)
+      .sort(
+        (a, b) => new Date(a.date_de_decision).getTime() - new Date(b.date_de_decision).getTime()
+      )
+
+    // When total events < maximum number of events, early return of sorted dates
+    if (sortedTimeline.length <= this.maximumNumberOfEvents) {
+      return sortedTimeline
+    }
+
+    // Splitting data into 3 groups (pasts, current, futures)
+    const currentIndex = sortedTimeline.findIndex((t) => Number(t.id) === audience.id)
+
+    if (currentIndex === -1) {
+      return sortedTimeline.slice(0, this.maximumNumberOfEvents)
+    }
+
+    const currentEvent = sortedTimeline[currentIndex]
+    const pastEvents = sortedTimeline.slice(0, currentIndex)
+    const futureEvents = sortedTimeline.slice(currentIndex + 1)
+
+    // Defining number of items per group according to preferences
+    let numberOfPastEvents = Math.min(this.preferredPositionForCurrentAudience, pastEvents.length)
+    const numberOfFutureEvents = Math.min(
+      futureEvents.length,
+      this.maximumNumberOfEvents - (1 + numberOfPastEvents)
+    )
+    if (numberOfPastEvents + numberOfFutureEvents !== this.maximumNumberOfEvents - 1) {
+      numberOfPastEvents = Math.min(
+        pastEvents.length,
+        this.maximumNumberOfEvents - 1 - numberOfFutureEvents
+      )
+    }
+
+    return [
+      ...pastEvents.slice(pastEvents.length - numberOfPastEvents),
+      currentEvent,
+      ...futureEvents.slice(0, numberOfFutureEvents),
+    ]
+  }
+}

--- a/app/services/audience_service.ts
+++ b/app/services/audience_service.ts
@@ -13,22 +13,6 @@ type SearchAudiencesQuery = {
   page?: number
 }
 
-type TimelineItem = {
-  id: number
-  date_de_decision?: string
-  degre_de_juridiction?: string
-  decision_pour_les_infractions_principales?: string
-  type_de_peine_pour_les_infractions_principales?: string
-}
-
-type NormalisedTimelineItem = {
-  id: number
-  date_de_decision: string
-  degre_de_juridiction?: string
-  decision_pour_les_infractions_principales?: string
-  type_de_peine_pour_les_infractions_principales?: string
-}
-
 export class AudienceService {
   /**
    * Get an audience if both the audience and its procedure are published.
@@ -120,77 +104,7 @@ export class AudienceService {
       query.andWhere('procedures.collectif_d_action_ou_lutte', searchQuery.collectif)
     }
 
-    const results = await query.paginate(searchQuery.page ?? 1, 50)
-
-    results.map((row) => {
-      row.timeline = this.filterTimeline(row.timeline, row.id)
-    })
-
-    return results
-  }
-
-  /**
-   * Filters out timeline for a given maximum number of events,
-   * and sorting it ascendant with a preferred position for current audience's date
-   * @param timeline
-   * @param audienceId
-   * @returns
-   */
-  private filterTimeline(timeline: TimelineItem[], audienceId: number) {
-    // Algorithm parameters
-    const maximumNumberOfEvents = 4
-    const preferredPositionForCurrentAudience = 1
-
-    // Inserting future date for unavailable dates
-    const normalisedTimeline: NormalisedTimelineItem[] = []
-    timeline.forEach((event) => {
-      normalisedTimeline.push({
-        ...event,
-        date_de_decision: event.date_de_decision ?? '2199-12-31',
-      })
-    })
-
-    // Sorting dates (ASC)
-    const sortedTimeline = [...normalisedTimeline].sort((a, b) => {
-      return new Date(a.date_de_decision).getTime() - new Date(b.date_de_decision).getTime()
-    })
-
-    // When total events < maximum number of events, early return of sorted dates
-    if (sortedTimeline.length <= maximumNumberOfEvents) {
-      return sortedTimeline
-    }
-
-    // Splitting data into 3 groups (pasts, current, futures)
-    const currentIndex = sortedTimeline.findIndex((t) => Number(t.id) === audienceId)
-
-    if (currentIndex === -1) {
-      return sortedTimeline.slice(0, maximumNumberOfEvents)
-    }
-
-    const currentEvent = sortedTimeline[currentIndex]
-    const pastEvents = sortedTimeline.slice(0, currentIndex)
-    const futureEvents = sortedTimeline.slice(currentIndex + 1)
-
-    // Defining number of items per group according to preferences
-    let numberOfPastEvents = Math.min(preferredPositionForCurrentAudience, pastEvents.length)
-    const numberOfFutureEvents = Math.min(
-      futureEvents.length,
-      maximumNumberOfEvents - (1 + numberOfPastEvents)
-    )
-    if (numberOfPastEvents + numberOfFutureEvents !== maximumNumberOfEvents - 1) {
-      numberOfPastEvents = Math.min(
-        pastEvents.length,
-        maximumNumberOfEvents - 1 - numberOfFutureEvents
-      )
-    }
-
-    // Building the filtered array
-    const filteredArray = []
-    filteredArray.push(...pastEvents.slice(pastEvents.length - numberOfPastEvents))
-    filteredArray.push(currentEvent)
-    filteredArray.push(...futureEvents.slice(0, numberOfFutureEvents))
-
-    return filteredArray
+    return query.paginate(searchQuery.page ?? 1, 50)
   }
 
   async getVilles(): Promise<Array<{ nom: string }>> {

--- a/tests/unit/timeline_mapper.spec.ts
+++ b/tests/unit/timeline_mapper.spec.ts
@@ -1,19 +1,19 @@
+import { TimelineDataMapper } from '#controllers/mappers/timeline_mapper'
 import { test } from '@japa/runner'
-import { AudienceService } from '#services/audience_service'
 
-test.group('Filter timeline algorithm', () => {
-  const service = new AudienceService()
+test.group('Timeline mapper algorithm', () => {
+  const timelineDataMapper = new TimelineDataMapper()
 
-  const mockEvent = (id: number, date: string | null, testProperty?: string) => ({
+  const mockEvent = (id: number, date?: string, testProperty?: string) => ({
     id,
-    date_de_decision: date ?? undefined,
-    degre_de_juridiction: testProperty ?? null,
+    date_de_decision: date,
+    degre_de_juridiction: testProperty,
   })
 
   test('should return unaltered event objects', async ({ assert }) => {
     const text = 'This text should remain unaltered'
     const timeline = [mockEvent(1, '2020-01-01', text)]
-    const result = (service as any).filterTimeline(timeline, 1)
+    const result = timelineDataMapper.map({ timeline, id: 1 })
     assert.equal(result[0].id, 1)
     assert.equal(result[0].degre_de_juridiction, text)
     assert.equal(result[0].date_de_decision, '2020-01-01')
@@ -21,7 +21,7 @@ test.group('Filter timeline algorithm', () => {
 
   test('should return all events when they are less than 4', ({ assert }) => {
     const timeline = [mockEvent(1, '2024-01-10'), mockEvent(2, '2024-01-20')]
-    const result = (service as any).filterTimeline(timeline, 1)
+    const result = timelineDataMapper.map({ timeline, id: 1 })
     assert.lengthOf(result, 2)
     assert.equal(result[0].id, 1)
   })
@@ -35,7 +35,7 @@ test.group('Filter timeline algorithm', () => {
       mockEvent(5, '2024-05-01'),
     ]
 
-    const result = (service as any).filterTimeline(timeline, 3)
+    const result = timelineDataMapper.map({ timeline, id: 3 })
 
     assert.lengthOf(result, 4, 'Timeline returned should contain 4 events')
     assert.equal(result[1].id, 3, 'Current audience should be the second item (index 1)')
@@ -55,14 +55,14 @@ test.group('Filter timeline algorithm', () => {
       mockEvent(4, '2024-04-01'),
       mockEvent(5, '2024-05-01'),
     ]
-    const result = (service as any).filterTimeline(timeline, 1)
+    const result = timelineDataMapper.map({ timeline, id: 1 })
     assert.lengthOf(result, 4)
     assert.equal(result[0].id, 1, 'Current audience is the first because no past event')
   })
 
   test('should handle correctly empty dates', ({ assert }) => {
-    const timeline = [mockEvent(1, '2024-01-01'), mockEvent(2, null), mockEvent(3, '2023-01-01')]
-    const result = (service as any).filterTimeline(timeline, 1)
+    const timeline = [mockEvent(1, '2024-01-01'), mockEvent(2), mockEvent(3, '2023-01-01')]
+    const result = timelineDataMapper.map({ timeline, id: 1 })
     assert.equal(result[0].id, 3, '2023 should be first')
     assert.equal(result[2].id, 2, 'Empry date should be the last (year 2199)')
   })
@@ -75,13 +75,13 @@ test.group('Filter timeline algorithm', () => {
       mockEvent(4, '2024-04-01'),
       mockEvent(5, '2024-05-01'),
     ]
-    const result = (service as any).filterTimeline(timeline, 5)
+    const result = timelineDataMapper.map({ timeline, id: 5 })
     assert.lengthOf(result, 4, 'Should fill with past events if no future events left')
   })
 
   test('should return 1 event there is only one event', ({ assert }) => {
     const timeline = [mockEvent(1, '2024-01-01')]
-    const result = (service as any).filterTimeline(timeline, 1)
+    const result = timelineDataMapper.map({ timeline, id: 1 })
     assert.lengthOf(result, 1)
   })
 })


### PR DESCRIPTION
- Introduction des mappers, pour modifier les ressources en sortie des contrôleurs.
- Léger refactoring de l'algo timeline de l'autre syntactique.
- Ajustement des tests unitaire à l'usage de TimelineDataMapper   