### PR TITLE
fix: move chef de preventions input out of more filters component

### DIFF
--- a/resources/js/date_range_picker.js
+++ b/resources/js/date_range_picker.js
@@ -21,11 +21,11 @@ export default class DateRangePicker {
       monthSelect: 'Choisir un mois',
       nextMonthButton: 'Mois suivant',
       nextYearButton: 'Année suivante',
-      picker: 'Choisir une dates',
+      picker: 'Choisir une date',
       previousMonthButton: 'Moi précédent',
       previousYearButton: 'Année précédente',
       todayButton: "Aujourd'hui",
-      yearSelect: 'Choisir une années',
+      yearSelect: 'Choisir une année',
     }
 
     this.#bind(value)

--- a/resources/views/components/more_filters.edge
+++ b/resources/views/components/more_filters.edge
@@ -189,14 +189,6 @@ You can display the values by adding `data-more-filters-value` on a html element
         <span class="position-absolute end-0 me-3">{{ svg('ph:caret-right') }}</span>
       </button>
 
-      <button type="button" class="dropdown-item" data-more-filters-goto="chefDePrevention">
-        Chef de prévention <span
-          class="more-filters-value fw-bold d-inline-block text-truncate align-text-bottom"
-          data-more-filters-value="chefDePrevention"
-        ></span>
-        <span class="position-absolute end-0 me-3">{{ svg('ph:caret-right') }}</span>
-      </button>
-
       <button type="button" class="dropdown-item" data-more-filters-goto="dateAudience">
         Date d'audience <span
           class="more-filters-value fw-bold d-inline-block text-truncate align-text-bottom"
@@ -283,21 +275,6 @@ You can display the values by adding `data-more-filters-value` on a html element
           options: collectifs.map(c => c.nom),
           selected: searchQuery.collectif ?? '',
           data: { ['data-more-filters-input']: "collectif" }
-        })
-      </div>
-    </div>
-
-    <div data-more-filters-step="chefDePrevention">
-      <button type="button" class="dropdown-item" data-more-filters-goto="menu">
-        {{ svg('ph:caret-left') }} Chef de prevention
-      </button>
-      <div class="p-2">
-        @!component('components/multi_select', {
-          name: 'chefDePrevention',
-          label: 'Chef de prévention',
-          options: chefDePreventionCategories.map(c => c.intitule),
-          selected: searchQuery.chefDePrevention ?? '',
-          data: { ['data-more-filters-input']: "chefDePrevention" }
         })
       </div>
     </div>

--- a/resources/views/pages/home.edge
+++ b/resources/views/pages/home.edge
@@ -22,7 +22,7 @@
     <div class="container my-5">
       <form class="mb-3" method="GET">
         <div class="row gx-2">
-          <div class="col-5">
+          <div class="col-3">
             <input
               name="search"
               value="{{ searchQuery.search ?? '' }}"
@@ -32,15 +32,24 @@
               autocomplete="off"
             />
           </div>
-          <div class="col-4">
+          <div class="col-3">
             @!component('components/date_range_picker', {
             name: 'dateDeLaDecision',
             label: 'Date de la décision',
             value: searchQuery.dateDeLaDecision ?? []
             })
           </div>
+          <div class="col-3">
+            @!component('components/multi_select', {
+              name: 'chefDePrevention',
+              label: 'Chef de prévention',
+              options: chefDePreventionCategories.map(c => c.intitule),
+              selected: searchQuery.chefDePrevention ?? '',
+              data: { ['data-more-filters-input']: "chefDePrevention" }
+            })
+          </div>
           <div class="col-2">
-            @!component('components/more_filters', { searchQuery, villes, juridictions, collectifs, chefDePreventionCategories })
+            @!component('components/more_filters', { searchQuery, villes, juridictions, collectifs })
           </div>
           <div class="col-1">
             <button class="btn btn-primary" type="submit" style="background-color: #0d6efd; height: 38px;">

--- a/resources/views/pages/home.edge
+++ b/resources/views/pages/home.edge
@@ -1,3 +1,13 @@
+@pushOnceTo('components')
+  <script type="module">
+    // strip wc-datepicker unwanted month and year form values, see: https://github.com/Sqrrl/wc-datepicker/issues/62
+    document.querySelector("form#search").addEventListener("formdata", function(event) {
+      event.formData.delete("month");
+      event.formData.delete("year");
+    });
+  </script>
+@end
+
 <!DOCTYPE html>
 <html lang="fr">
 
@@ -20,7 +30,7 @@
     </h1>
 
     <div class="container my-5">
-      <form class="mb-3" method="GET">
+      <form id="search" class="mb-3" method="GET">
         <div class="row gx-2">
           <div class="col-3">
             <input


### PR DESCRIPTION
Dans un commentaire de ce ticket #73 il est dit :

> garder le filtre chef de prévention au niveau des filtres principaux.

J'ai donc appliqué ce changement

@jbuiquan j'ai aussi appliquer les fixes que je n'avais pas encore pris en compte 