### PR TITLE
fix: improve result card ui #141

### DIFF
--- a/app/controllers/home_controller.ts
+++ b/app/controllers/home_controller.ts
@@ -32,9 +32,12 @@ export default class HomeController {
       villes,
       collectifs,
       audiences: audiences.map((audience) => {
-        audience.timeline = timelineDataMapper.map(audience)
-        return audience
+        return {
+          ...audience,
+          timeline: timelineDataMapper.map(audience),
+        }
       }),
+      total: audiences.total,
       paginations,
       searchQuery,
       chefDePreventionCategories,

--- a/app/controllers/mappers/timeline_mapper.ts
+++ b/app/controllers/mappers/timeline_mapper.ts
@@ -1,9 +1,48 @@
-type TimelineItem = {
+/**
+ * Resulting type of the `searchAudiences` query.
+ */
+export type TimelineDbResultItem = {
   id: number
   date_de_decision?: string
   degre_de_juridiction?: string
   decision_pour_les_infractions_principales?: string
   type_de_peine_pour_les_infractions_principales?: string
+}
+
+/*
+ * Timeline item to be rendered in the view, with or without date.
+ * Three types :
+ * - date des faits (type: 'faits', date: string)
+ * - audience with date (type: 'audience', date: string)
+ * - audience à venir (type: 'audience_a_venir', date: undefined)
+ */
+export type TimelineItem =
+  | TimelineDateDesFaitsItem
+  | TimelineAudienceItem
+  | TimelineAudienceAVenirItem
+
+type BaseAudienceItem = {
+  id: number
+  degre_de_juridiction?: string
+  decision_pour_les_infractions_principales?: string
+  type_de_peine_pour_les_infractions_principales?: string
+  skipped_before?: number
+  skipped_after?: number
+}
+
+export type TimelineAudienceItem = BaseAudienceItem & {
+  type: 'audience'
+  date: string
+}
+
+export type TimelineAudienceAVenirItem = BaseAudienceItem & {
+  type: 'audience_a_venir'
+  date: null
+}
+
+export type TimelineDateDesFaitsItem = {
+  type: 'faits'
+  date: string
 }
 
 /**
@@ -12,40 +51,76 @@ type TimelineItem = {
  */
 export class TimelineDataMapper {
   constructor(
-    private readonly maximumNumberOfEvents = 3,
+    private readonly maximumNumberOfEvents = 4, // date des faits will be first
     private readonly preferredPositionForCurrentAudience = 1
   ) {}
 
-  map(audience: { timeline: TimelineItem[]; id: number }) {
-    const eventsWithDate: (TimelineItem & { date_de_decision: string })[] = []
-    const eventsWithoutDate: TimelineItem[] = []
+  map(audience: {
+    id: number
+    date_des_faits: string | null
+    timeline: TimelineDbResultItem[]
+  }): TimelineItem[] {
+    const eventsWithDate: TimelineAudienceItem[] = []
+    const eventsWithoutDate: TimelineAudienceAVenirItem[] = []
+
+    // We need to reserve one slot for date des faits if it exists
+    const maximumNumberOfEvents = this.maximumNumberOfEvents - (audience.date_des_faits ? 1 : 0)
+
+    /**
+     * Build the final timeline with the date des faits at first position if it exists, then the sorted audiences.
+     * @param sortedAudiences
+     * @returns
+     */
+    function buildTimeline(
+      sortedAudiences: Array<TimelineAudienceItem | TimelineAudienceAVenirItem>
+    ): TimelineItem[] {
+      const dateDesFaitsItem: TimelineDateDesFaitsItem | null = audience.date_des_faits
+        ? {
+            type: 'faits',
+            date: audience.date_des_faits,
+          }
+        : null
+      if (dateDesFaitsItem) {
+        return [dateDesFaitsItem, ...sortedAudiences]
+      }
+      return [...sortedAudiences]
+    }
 
     for (const item of audience.timeline) {
       if (item.date_de_decision) {
-        eventsWithDate.push(item as TimelineItem & { date_de_decision: string })
+        eventsWithDate.push({
+          ...item,
+          type: 'audience',
+          date: item.date_de_decision,
+        })
       } else {
-        eventsWithoutDate.push(item)
+        eventsWithoutDate.push({
+          ...item,
+          type: 'audience_a_venir',
+          date: null,
+        })
       }
     }
 
-    eventsWithDate.sort(
-      (a, b) => new Date(a.date_de_decision).getTime() - new Date(b.date_de_decision).getTime()
-    )
+    eventsWithDate.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
 
     eventsWithoutDate.sort((a, b) => Number(a.id) - Number(b.id))
 
     const sortedTimeline = [...eventsWithDate, ...eventsWithoutDate]
 
     // When total events < maximum number of events, early return of sorted dates
-    if (sortedTimeline.length <= this.maximumNumberOfEvents) {
-      return sortedTimeline
+    if (sortedTimeline.length <= maximumNumberOfEvents) {
+      return buildTimeline(sortedTimeline)
     }
 
     // Splitting sortedTimeline into 3 groups (pasts, current, futures)
     const currentIndex = sortedTimeline.findIndex((t) => Number(t.id) === audience.id)
 
+    // Maximum number of events > complete timeline, audience is not present in the timeline, we return the most recent events trimmed to the maximum number of events
     if (currentIndex === -1) {
-      return sortedTimeline.slice(0, this.maximumNumberOfEvents)
+      const trimmedSize = sortedTimeline.length - maximumNumberOfEvents
+      sortedTimeline[maximumNumberOfEvents - 1].skipped_after = trimmedSize
+      return buildTimeline(sortedTimeline.slice(0, maximumNumberOfEvents))
     }
 
     const currentEvent = sortedTimeline[currentIndex]
@@ -56,19 +131,30 @@ export class TimelineDataMapper {
     let numberOfPastEvents = Math.min(this.preferredPositionForCurrentAudience, pastEvents.length)
     const numberOfFutureEvents = Math.min(
       futureEvents.length,
-      this.maximumNumberOfEvents - (1 + numberOfPastEvents)
+      maximumNumberOfEvents - (1 + numberOfPastEvents)
     )
-    if (numberOfPastEvents + numberOfFutureEvents !== this.maximumNumberOfEvents - 1) {
+    if (numberOfPastEvents + numberOfFutureEvents !== maximumNumberOfEvents - 1) {
       numberOfPastEvents = Math.min(
         pastEvents.length,
-        this.maximumNumberOfEvents - 1 - numberOfFutureEvents
+        maximumNumberOfEvents - 1 - numberOfFutureEvents
       )
     }
 
-    return [
-      ...pastEvents.slice(pastEvents.length - numberOfPastEvents),
+    const pastEventsStartIndex = pastEvents.length - numberOfPastEvents
+    const trimmedBeforePastEvents = pastEventsStartIndex
+    if (trimmedBeforePastEvents > 0) {
+      pastEvents[pastEventsStartIndex].skipped_before = trimmedBeforePastEvents
+    }
+    const futureEventsEndIndex = numberOfFutureEvents
+    const trimmedAfterFutureEvents = futureEvents.length - numberOfFutureEvents
+    if (trimmedAfterFutureEvents > 0) {
+      futureEvents[futureEventsEndIndex - 1].skipped_after = trimmedAfterFutureEvents
+    }
+
+    return buildTimeline([
+      ...pastEvents.slice(pastEventsStartIndex),
       currentEvent,
-      ...futureEvents.slice(0, numberOfFutureEvents),
-    ]
+      ...futureEvents.slice(0, futureEventsEndIndex),
+    ])
   }
 }

--- a/app/controllers/mappers/timeline_mapper.ts
+++ b/app/controllers/mappers/timeline_mapper.ts
@@ -12,7 +12,7 @@ type TimelineItem = {
  */
 export class TimelineDataMapper {
   constructor(
-    private readonly maximumNumberOfEvents = 4,
+    private readonly maximumNumberOfEvents = 3,
     private readonly preferredPositionForCurrentAudience = 1
   ) {}
 

--- a/app/controllers/mappers/timeline_mapper.ts
+++ b/app/controllers/mappers/timeline_mapper.ts
@@ -1,13 +1,5 @@
-/**
- * Resulting type of the `searchAudiences` query.
- */
-export type TimelineDbResultItem = {
-  id: number
-  date_de_decision?: string
-  degre_de_juridiction?: string
-  decision_pour_les_infractions_principales?: string
-  type_de_peine_pour_les_infractions_principales?: string
-}
+import type { SearchAudiencesResponse } from '#services/audience_service'
+import { DateTime } from 'luxon'
 
 /*
  * Timeline item to be rendered in the view, with or without date.
@@ -23,16 +15,16 @@ export type TimelineItem =
 
 type BaseAudienceItem = {
   id: number
-  degre_de_juridiction?: string
-  decision_pour_les_infractions_principales?: string
-  type_de_peine_pour_les_infractions_principales?: string
+  degre_de_juridiction: string | null
+  decision_pour_les_infractions_principales: string | null
+  type_de_peine_pour_les_infractions_principales: string | null
   skipped_before?: number
   skipped_after?: number
 }
 
 export type TimelineAudienceItem = BaseAudienceItem & {
   type: 'audience'
-  date: string
+  date: DateTime
 }
 
 export type TimelineAudienceAVenirItem = BaseAudienceItem & {
@@ -42,7 +34,7 @@ export type TimelineAudienceAVenirItem = BaseAudienceItem & {
 
 export type TimelineDateDesFaitsItem = {
   type: 'faits'
-  date: string
+  date: DateTime
 }
 
 /**
@@ -57,8 +49,8 @@ export class TimelineDataMapper {
 
   map(audience: {
     id: number
-    date_des_faits: string | null
-    timeline: TimelineDbResultItem[]
+    date_des_faits: DateTime | null
+    timeline: SearchAudiencesResponse[number]['timeline']
   }): TimelineItem[] {
     const eventsWithDate: TimelineAudienceItem[] = []
     const eventsWithoutDate: TimelineAudienceAVenirItem[] = []
@@ -102,9 +94,9 @@ export class TimelineDataMapper {
       }
     }
 
-    eventsWithDate.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+    eventsWithDate.sort((a, b) => a.date.toMillis() - b.date.toMillis())
 
-    eventsWithoutDate.sort((a, b) => Number(a.id) - Number(b.id))
+    eventsWithoutDate.sort((a, b) => a.id - b.id)
 
     const sortedTimeline = [...eventsWithDate, ...eventsWithoutDate]
 
@@ -114,7 +106,7 @@ export class TimelineDataMapper {
     }
 
     // Splitting sortedTimeline into 3 groups (pasts, current, futures)
-    const currentIndex = sortedTimeline.findIndex((t) => Number(t.id) === audience.id)
+    const currentIndex = sortedTimeline.findIndex((t) => t.id === audience.id)
 
     // Maximum number of events > complete timeline, audience is not present in the timeline, we return the most recent events trimmed to the maximum number of events
     if (currentIndex === -1) {

--- a/app/services/audience_service.ts
+++ b/app/services/audience_service.ts
@@ -1,6 +1,9 @@
 import { multiSelectToStringList } from '#database/mappers'
 import Audience from '#models/audience'
+import type Procedure from '#models/procedure'
 import db from '@adonisjs/lucid/services/db'
+import type { SimplePaginatorContract } from '@adonisjs/lucid/types/querybuilder'
+import { DateTime } from 'luxon'
 
 type SearchAudiencesQuery = {
   search?: string
@@ -14,6 +17,31 @@ type SearchAudiencesQuery = {
   collectif?: string[]
   page?: number
 }
+
+/**
+ * This is declarative type, if search method change  then it might need to be updated !
+ * This type is reinforced by unit tests, feel free to improve them.
+ */
+export type SearchAudiencesResponse = SimplePaginatorContract<
+  Audience &
+    Pick<
+      Procedure,
+      | 'titre'
+      | 'faits_detailles'
+      | 'faits_concis'
+      | 'collectif_d_action_ou_lutte'
+      | 'date_des_faits'
+    > & {
+      timeline: Array<{
+        id: number
+        date_de_decision: DateTime | null
+        degre_de_juridiction: string | null
+        decision_pour_les_infractions_principales: string | null
+        type_de_peine_pour_les_infractions_principales: string | null
+        publiee: boolean
+      }>
+    }
+>
 
 export class AudienceService {
   /**
@@ -33,7 +61,7 @@ export class AudienceService {
       .firstOrFail()
   }
 
-  async searchAudiences(searchQuery: SearchAudiencesQuery) {
+  async searchAudiences(searchQuery: SearchAudiencesQuery): Promise<SearchAudiencesResponse> {
     const query = db
       .query()
       .with('timeline', (q) => {
@@ -125,16 +153,35 @@ export class AudienceService {
       )
     }
 
-    return query.paginate(searchQuery.page ?? 1, 50).then((page) => {
-      return page.map((audience) => ({
-        ...audience,
-        mots_cles: multiSelectToStringList(audience.mots_cles),
-        chefs_de_prevention_categorie: multiSelectToStringList(
-          audience.chefs_de_prevention_categorie
-        ),
-        collectif_d_action_ou_lutte: multiSelectToStringList(audience.collectif_d_action_ou_lutte),
-      }))
-    }) as ReturnType<typeof query.paginate>
+    const pagination = await query.paginate(searchQuery.page ?? 1, 50)
+
+    // Perform audiences mutation. A simple `.map()` lose the pagination metadata
+    pagination.forEach((audience) => {
+      audience.date_des_faits = audience.date_des_faits
+        ? DateTime.fromJSDate(audience.date_des_faits)
+        : null
+      audience.date_de_l_audience = audience.date_de_l_audience
+        ? DateTime.fromJSDate(audience.date_de_l_audience)
+        : null
+      audience.date_de_decision = audience.date_de_decision
+        ? DateTime.fromJSDate(audience.date_de_decision)
+        : null
+      audience.mots_cles = multiSelectToStringList(audience.mots_cles)
+      audience.chefs_de_prevention_categorie = multiSelectToStringList(
+        audience.chefs_de_prevention_categorie
+      )
+      audience.collectif_d_action_ou_lutte = multiSelectToStringList(
+        audience.collectif_d_action_ou_lutte
+      )
+      audience.timeline = audience.timeline.map((t: Record<string, any>) => {
+        return {
+          ...t,
+          date_de_decision: t.date_de_decision ? DateTime.fromISO(t.date_de_decision) : null,
+        }
+      })
+    })
+
+    return pagination as SearchAudiencesResponse
   }
 
   async getVilles(): Promise<Array<{ nom: string }>> {

--- a/app/services/audience_service.ts
+++ b/app/services/audience_service.ts
@@ -61,6 +61,7 @@ export class AudienceService {
         'procedures.faits_detailles',
         'procedures.faits_concis',
         'procedures.collectif_d_action_ou_lutte',
+        'procedures.date_des_faits',
         'timeline.audiences as timeline'
       )
       .from('audiences')

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -3,23 +3,10 @@
 .timeline {
   display: flex;
   flex-direction: row;
-  margin-inline-start: 8px;
 }
 
 .timeline .flex-1 {
   flex: 1;
-}
-
-.timeline .timeline-node:first-child::before {
-  content: '';
-  position: absolute;
-  width: 8px;
-  height: 1px;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #ced4da;
-  top: 5px;
-  left: -8px;
 }
 
 .timeline-node {
@@ -30,7 +17,11 @@
   padding-left: 4px;
   padding-right: 4px;
   font-size: 0.8rem;
-  min-width: 80px;
+  min-width: 60px;
+
+  &.timeline-node-start:not(.timeline-node-start--skipped) {
+    min-width: 25px;
+  }
 }
 
 .timeline-node > .timeline-pin {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -30,6 +30,7 @@
   padding-left: 4px;
   padding-right: 4px;
   font-size: 0.8rem;
+  min-width: 80px;
 }
 
 .timeline-node > .timeline-pin {
@@ -40,6 +41,38 @@
   border-radius: 10px;
   border-width: 1px;
   z-index: 2;
+}
+
+.timeline-node.timeline-node-skipped {
+  --timeline-skipped-color: #6c757d;
+  --timeline-skipped-bg: var(--relx-gray-background);
+
+  &::before,
+  &::after {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    color: var(--timeline-skipped-color);
+    background-color: var(--timeline-skipped-bg);
+    border-color: var(--timeline-skipped-color);
+    border-style: solid;
+    border-radius: 10px;
+    border-width: 1px;
+    z-index: 2;
+    top: -4px;
+    text-align: center;
+    font-weight: 600;
+  }
+}
+
+.timeline-node.timeline-node-skipped[data-skipped-before]::before {
+  content: attr(data-skipped-before);
+  left: -30px;
+}
+
+.timeline-node.timeline-node-skipped[data-skipped-after]::after {
+  content: attr(data-skipped-after);
+  left: 30px;
 }
 
 .timeline-node > .timeline-pin.pin-fill {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -3,13 +3,27 @@
 .timeline {
   display: flex;
   flex-direction: row;
+  margin-inline-start: 8px;
 }
 
 .timeline .flex-1 {
   flex: 1;
 }
 
+.timeline .timeline-node:first-child::before {
+  content: '';
+  position: absolute;
+  width: 8px;
+  height: 1px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #ced4da;
+  top: 5px;
+  left: -8px;
+}
+
 .timeline-node {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: start;

--- a/resources/views/components/more_filters.edge
+++ b/resources/views/components/more_filters.edge
@@ -147,14 +147,14 @@ You can display the values by adding `data-more-filters-value` on a html element
 
 <div id="more-filters" class="dropdown">
   <button
-    class="btn btn-light dropdown-toggle"
+    class="btn btn-light d-inline-flex gap-1"
     type="button"
     data-bs-toggle="dropdown"
     data-bs-config='{ "autoClose":"outside" }'
   >
     <span class="ms-1">Plus de filtres</span>
+    <span class="badge text-bg-primary rounded-pill"></span>
   </button>
-  <span class="badge text-bg-primary rounded-pill"></span>
   <div class="dropdown-menu dropdown-menu-end" style="min-width: 20rem">
     <div data-more-filters-step="menu">
       <button type="button" class="dropdown-item" data-more-filters-goto="ville">
@@ -208,7 +208,7 @@ You can display the values by adding `data-more-filters-value` on a html element
 
     <div data-more-filters-step="ville">
       <button type="button" class="dropdown-item" data-more-filters-goto="menu">
-        {{ svg('ph:caret-left') }} Ville 
+        {{ svg('ph:caret-left') }} Ville
       </button>
       <div class="p-2">
         <select name="ville" class="form-select" data-more-filters-input="ville">

--- a/resources/views/components/search/emptyResult.edge
+++ b/resources/views/components/search/emptyResult.edge
@@ -13,7 +13,7 @@
   <section class="vstack p-5 gap-3 justify-content-center">
     {{{ buildHeader('Elle nous aurait échappé ?') }}}
     <p class="lead">
-      Aucun résultat n'a été trouvé ! Si vous aviez en tête une décision ou une procédure intéressante à connaître pour la défense de militant.es, merci de nous en parler via le contact ci-dessous.
+      Aucun résultat n'a été trouvé ! Si vous aviez en tête une décision ou une procédure intéressante à connaître pour la défense de militant⋅es, merci de nous en parler via le contact ci-dessous.
     </p>
     <a href="mailto:{{ env.get('CONTACT_EMAIL') }}" class="btn btn-accent align-self-start">
       {{ env.get('CONTACT_EMAIL') }}

--- a/resources/views/components/timeline.edge
+++ b/resources/views/components/timeline.edge
@@ -1,6 +1,14 @@
 @let (dateFormat = 'dd.MM.yy')
 
 <div class="timeline d-flex">
+  <!-- Date des faits -->
+  <div class="timeline-node flex-1">
+    <span class="timeline-link"></span>
+    <span class="timeline-pin pin-fill"></span>
+    <span class="label mt-1">{{ DateTime.fromISO(date_des_faits).toFormat(dateFormat) }}</span>
+    <span class="label mt-1 fw-bold">Faits</span>
+  </div>
+  <!-- Audiences -->
   @each(t in data)
     @let(decisionClass = html.classNames({
       'conviction': t.decision_pour_les_infractions_principales === 'Condamnation',

--- a/resources/views/components/timeline.edge
+++ b/resources/views/components/timeline.edge
@@ -1,14 +1,6 @@
 @let (dateFormat = 'dd.MM.yy')
 
 <div class="timeline d-flex">
-  <!-- Date des faits -->
-  <div class="timeline-node flex-1">
-    <span class="timeline-link"></span>
-    <span class="timeline-pin pin-fill"></span>
-    <span class="label mt-1">{{ DateTime.fromISO(date_des_faits).toFormat(dateFormat) }}</span>
-    <span class="label mt-1 fw-bold">Faits</span>
-  </div>
-  <!-- Audiences -->
   @each(t in data)
     @let(decisionClass = html.classNames({
       'conviction': t.decision_pour_les_infractions_principales === 'Condamnation',
@@ -16,20 +8,29 @@
     }))
 
     @let(timelinePinClass = html.classNames({
-      'pin-fill': t.date_de_decision !== null,
-      'pin-stroke': t.date_de_decision === null
+      'pin-fill': t.date !== null,
+      'pin-stroke': t.date === null
     }))
-
-    <div class="timeline-node flex-1 {{ html.classNames({ 'current': t.id == current }) }}">
+    <div
+      class="timeline-node flex-1 {{ html.classNames({ 'current': t.id == current, 'timeline-node-skipped': t.skipped_before || t.skipped_after }) }}"
+      {{ html.attrs(t.skipped_before ? { 'data-skipped-before': t.skipped_before } : {}) }}
+      {{ html.attrs(t.skipped_after ? { 'data-skipped-after': t.skipped_after } : {}) }}
+    >
       <span class="timeline-link"></span>
       <span class="timeline-pin {{ timelinePinClass }}"></span>
-      <span class="label mt-1">{{ t.date_de_decision === null ? "À venir" : DateTime.fromISO(t.date_de_decision).toFormat(dateFormat) }}</span>
-      <span class="label mt-1">{{ t.degre_de_juridiction || "\u00A0" }}</span>
-      @if (t.type_de_peine_pour_les_infractions_principales)
-        <span class="label mt-1 conclusion d-flex align-items-center gap-1 {{ decisionClass }}">
-          @svg('ph:gavel-fill', { class:"flex-shrink-0" })
-          {{ t.type_de_peine_pour_les_infractions_principales }}
-          </span>
+      <span class="label mt-2">{{ t.date === null ? "À venir" : DateTime.fromISO(t.date).toFormat(dateFormat) }}</span>
+      @if (t.type ==='faits')
+        <span class="label mt-1 fw-bold">Faits</span>
+      @else
+        @if (t.degre_de_juridiction)
+          <span class="label mt-1">{{ t.degre_de_juridiction }}</span>
+        @end
+        @if (t.type_de_peine_pour_les_infractions_principales)
+          <span class="label mt-1 conclusion d-flex align-items-center gap-1 {{ decisionClass }}">
+            @svg('ph:gavel-fill', { class:"flex-shrink-0" })
+            {{ t.type_de_peine_pour_les_infractions_principales }}
+            </span>
+        @endif
       @endif
     </div>
   @end

--- a/resources/views/components/timeline.edge
+++ b/resources/views/components/timeline.edge
@@ -12,21 +12,17 @@
       'pin-stroke': t.date_de_decision === null
     }))
 
-    @let(href = html.attrs({ href: t.publiee ? `/audiences/${t.id}` : null }))
-
-    <a class="flex-1" {{ href }}>
-      <div class="timeline-node {{ html.classNames({ 'current': t.id == current }) }}">
-        <span class="timeline-link"></span>
-        <span class="timeline-pin {{ timelinePinClass }}"></span>
-        <span class="label mt-1">{{ t.date_de_decision === null ? "À venir" : DateTime.fromISO(t.date_de_decision).toFormat(dateFormat) }}</span>
-        <span class="label mt-1">{{ t.degre_de_juridiction || "\u00A0" }}</span>
-        @if (t.type_de_peine_pour_les_infractions_principales)
-          <span class="label mt-1 conclusion d-flex align-items-center gap-1 {{ decisionClass }}">
-            @svg('ph:gavel-fill', { class:"flex-shrink-0" })
-            {{ t.type_de_peine_pour_les_infractions_principales }}
+    <div class="timeline-node flex-1 {{ html.classNames({ 'current': t.id == current }) }}">
+      <span class="timeline-link"></span>
+      <span class="timeline-pin {{ timelinePinClass }}"></span>
+      <span class="label mt-1">{{ t.date_de_decision === null ? "À venir" : DateTime.fromISO(t.date_de_decision).toFormat(dateFormat) }}</span>
+      <span class="label mt-1">{{ t.degre_de_juridiction || "\u00A0" }}</span>
+      @if (t.type_de_peine_pour_les_infractions_principales)
+        <span class="label mt-1 conclusion d-flex align-items-center gap-1 {{ decisionClass }}">
+          @svg('ph:gavel-fill', { class:"flex-shrink-0" })
+          {{ t.type_de_peine_pour_les_infractions_principales }}
           </span>
-        @endif
-      </div>
-    </a>
+      @endif
+    </div>
   @end
 </div>

--- a/resources/views/components/timeline.edge
+++ b/resources/views/components/timeline.edge
@@ -1,7 +1,7 @@
 @let (dateFormat = 'dd.MM.yy')
 
 <div class="timeline d-flex">
-  @each(t in data)
+  @each((t, index) in data)
     @let(decisionClass = html.classNames({
       'conviction': t.decision_pour_les_infractions_principales === 'Condamnation',
       'acquittal': t.decision_pour_les_infractions_principales === 'Relaxe'
@@ -11,6 +11,15 @@
       'pin-fill': t.date !== null,
       'pin-stroke': t.date === null
     }))
+    <!-- Add a special node at the start of the timeline to display a continued line toward past -->
+    @if (index === 0)
+      <div
+        class="timeline-node timeline-node-start {{ html.classNames({ 'timeline-node-start--skipped': t.skipped_before }) }}"
+      >
+        <span class="timeline-link"></span>
+      </div>
+    @endif
+    
     <div
       class="timeline-node flex-1 {{ html.classNames({ 'current': t.id == current, 'timeline-node-skipped': t.skipped_before || t.skipped_after }) }}"
       {{ html.attrs(t.skipped_before ? { 'data-skipped-before': t.skipped_before } : {}) }}

--- a/resources/views/pages/audience.edge
+++ b/resources/views/pages/audience.edge
@@ -98,7 +98,7 @@
                   aria-selected="{{ currentAudience.id === audience.id ? 'true' : 'false' }}"
                 >
                   {{ audience.degre_de_juridiction }}
-                  <small class="text-secondary">{{ audience.date_de_l_audience.toFormat(dateFormat) }}</small>
+                  <small class="text-secondary">{{ audience.date_de_l_audience ? audience.date_de_l_audience.toFormat(dateFormat) : 'date non disponible' }}</small>
                 </button>
               </li>
             @end
@@ -114,7 +114,7 @@
               >
                 {{-- For better accessibility hierarchy --}}
                 <h2 class="visually-hidden">
-                  Détails de l'audience {{ audience.degre_de_juridiction }} du {{ audience.date_de_l_audience.toFormat(dateFormat) }}
+                  Détails de l'audience {{ audience.degre_de_juridiction }} {{ audience.date_de_l_audience ? `du ${audience.date_de_l_audience.toFormat(dateFormat)}` : '' }}
                 </h2>
                 <div class="d-flex flex-column gap-5">
                   <div class="row g-3 align-items-stretch">

--- a/resources/views/pages/home.edge
+++ b/resources/views/pages/home.edge
@@ -71,24 +71,24 @@
 
       <!-- Hidden - Accessibilité : Annonce du nombre de résultats trouvés -->
       <div aria-live="polite" aria-atomic="true" class="visually-hidden">
-        @if (audiences.length === 0)
+        @if (total === 0)
           Aucun résultat trouvé.
-        @elseif (audiences.length === 1)
+        @elseif (total === 1)
           1 résultat trouvé.
         @else
-          {{ audiences.length }} résultats trouvés.
+          {{ total }} résultats trouvés.
         @endif
       </div>
 
-      @if (audiences.length > 0)
+      @if (total > 0)
         <div class="vstack gap-4">
-          @if (audiences.length === 1)
+          @if (total === 1)
             <p class="h4 mb-0">
               1 résultat trouvé
             </p>
-          @elseif (audiences.length > 1)
+          @elseif (total > 1)
             <p class="h4 mb-0">
-              {{ audiences.length }} résultats trouvés
+              {{ total }} résultats trouvés
             </p>
           @endif
           @each(audience in audiences)
@@ -112,7 +112,7 @@
                       <div class="row">
                         <p class="mb-1 d-flex align-items-center gap-1">
                           @svg('ph:calendar-dot-fill')
-                          Audience : {{ DateTime.fromJSDate(audience.date_de_l_audience).toFormat(dateFormat) }}
+                          Audience : {{ audience.date_de_l_audience ? audience.date_de_l_audience.toFormat(dateFormat) : 'date non disponible' }}
                         </p>
                         @if(audience.juridiction && audience.ville_de_l_audience)
                           <p class="mb-1 d-flex align-items-center gap-1">

--- a/resources/views/pages/home.edge
+++ b/resources/views/pages/home.edge
@@ -156,7 +156,7 @@
 
                     <div class="col-lg-7 d-flex flex-column gap-2">
                       <div class="row bg-gray rounded-3 p-3">
-                        <div class="col-lg-5 d-flex flex-column gap-1 px-0 mb-3 mb-lg-0">
+                        <div class="col-lg-5 d-flex flex-column gap-1 mb-3 mb-lg-0">
                           <h3 class="text-purple small d-flex align-items-center gap-1">
                             @svg('ph:gavel-fill')
                             Faits et chronologie
@@ -170,11 +170,11 @@
                           </p>
                         </div>
                         <div class="col-lg-7 d-flex justify-content-center justify-content-lg-end align-items-center">
-                          @!component('components/timeline', { data: audience.timeline, current: audience.id })
+                          @!component('components/timeline', { data: audience.timeline, current: audience.id, date_des_faits: audience.date_des_faits })
                         </div>
                       </div>
                       <div class="row bg-gray rounded-3 p-3">
-                        <div class="col-12 d-flex flex-column gap-1 px-0">
+                        <div class="col-12 d-flex flex-column gap-1">
                           <h3 class="text-purple small d-flex align-items-center gap-1">
                             <img class="summary-icon" src="{{ asset('resources/images/summary_icon.svg') }}" alt="summary icon" />Extrait de la décision
                           </h3>
@@ -188,7 +188,7 @@
                         </div>
                       </div>
                       <div class="row bg-gray rounded-3 p-3">
-                        <div class="col-12 d-flex flex-column gap-1 px-0">
+                        <div class="col-12 d-flex flex-column gap-1">
                           <h3 class="text-purple small d-flex align-items-center gap-1">
                             <img
                               class="msde-leaf-icon me-1"

--- a/resources/views/pages/home.edge
+++ b/resources/views/pages/home.edge
@@ -80,131 +80,136 @@
         @endif
       </div>
 
-      @if (audiences.length === 1)
-        <p>
-          1 résultat trouvé:
-        </p>
-      @elseif (audiences.length > 1)
-        <p>
-          {{ audiences.length }} résultats trouvés:
-        </p>
-      @endif
-      
       @if (audiences.length > 0)
         <div class="vstack gap-4">
+          @if (audiences.length === 1)
+            <p class="h4 mb-0">
+              1 résultat trouvé
+            </p>
+          @elseif (audiences.length > 1)
+            <p class="h4 mb-0">
+              {{ audiences.length }} résultats trouvés
+            </p>
+          @endif
           @each(audience in audiences)
-            <div class="card rounded-5">
-              <div class="card-body">
-                <div class="row m-1 gy-3 gy-lg-0">
-                  <div class="col-lg-5 vstack gap-4 justify-content-center align-items-start">
-                    <h2 class="card-title fs-4">
-                      {{ audience.titre }}
-                    </h2>
-                    @if(audience.decision_pour_les_infractions_principales)
-                      <span class="badge rounded-pill text-bg-purple">
-                        {{ audience.decision_pour_les_infractions_principales }}
+            <a
+              class="text-decoration-none"
+              href="{{ route('audiences.show', { id: audience.id }) }}"
+              aria-label="Ouvrir la page de détail de {{ audience.titre }}"
+            >
+              <div class="card rounded-5">
+                <div class="card-body">
+                  <div class="row m-1 gy-3 gy-lg-0">
+                    <div class="col-lg-5 vstack gap-4 justify-content-center align-items-start">
+                      <h2 class="card-title fs-4">
+                        {{ audience.titre }}
+                      </h2>
+                      @if(audience.decision_pour_les_infractions_principales)
+                        <span class="badge rounded-pill text-bg-purple">
+                          {{ audience.decision_pour_les_infractions_principales }}
                       </span>
-                    @endif
-                    <div class="row">
-                      <p class="mb-1 d-flex align-items-center gap-1">
-                        @svg('ph:calendar-dot-fill')
-                        Audience : {{ DateTime.fromJSDate(audience.date_de_l_audience).toFormat(dateFormat) }}
-                      </p>
-                      @if(audience.juridiction && audience.ville_de_l_audience)
-                        <p class="mb-1 d-flex align-items-center gap-1">
-                          @svg('ph:bank-fill')
-                          {{ audience.juridiction }} de <span class="text-capitalize">{{ audience.ville_de_l_audience.toLowerCase() }}</span>
-                        </p>
-                      @elseif(audience.juridiction || audience.ville_de_l_audience)
-                        <p class="mb-1 d-flex align-items-center gap-1">
-                          @svg('ph:bank-fill')
-                          {{ audience.juridiction ?? "" }}<span class="text-capitalize">{{ audience.ville_de_l_audience?.toLowerCase() ?? "" }}</span>
-                        </p>
                       @endif
-                      @if(audience.chefs_de_prevention_categorie?.length)
+                      <div class="row">
                         <p class="mb-1 d-flex align-items-center gap-1">
-                          @svg('ph:scales-fill')
-                          {{ audience.chefs_de_prevention_categorie.join(', ') }}
+                          @svg('ph:calendar-dot-fill')
+                          Audience : {{ DateTime.fromJSDate(audience.date_de_l_audience).toFormat(dateFormat) }}
                         </p>
-                      @endif
-                      @if(audience.type_de_peine_pour_les_infractions_principales)
-                        <p class="mb-1 d-flex align-items-center gap-1">
-                          @svg('ph:gavel-fill')
-                          {{ audience.type_de_peine_pour_les_infractions_principales }}
-                        </p>
-                      @endif
-                    </div>
-                    @if (audience.fondement_de_la_relaxe || audience.collectif_d_action_ou_lutte?.length)
-                      <div class="d-flex flex-column align-items-start gap-2">
-                        @if (audience.fondement_de_la_relaxe)
-                          <span class="badge rounded-pill border text-secondary">
-                            {{ audience.fondement_de_la_relaxe }}
-                          </span>
+                        @if(audience.juridiction && audience.ville_de_l_audience)
+                          <p class="mb-1 d-flex align-items-center gap-1">
+                            @svg('ph:bank-fill')
+                            {{ audience.juridiction }} de <span class="text-capitalize">{{ audience.ville_de_l_audience.toLowerCase() }}</span>
+                          </p>
+                        @elseif(audience.juridiction || audience.ville_de_l_audience)
+                          <p class="mb-1 d-flex align-items-center gap-1">
+                            @svg('ph:bank-fill')
+                            {{ audience.juridiction ?? "" }}<span class="text-capitalize">{{ audience.ville_de_l_audience?.toLowerCase() ?? "" }}</span>
+                          </p>
                         @endif
-                        @each(collectif in audience.collectif_d_action_ou_lutte)
-                          <span class="badge rounded-pill border text-secondary">
-                            {{ collectif }}
+                        @if(audience.chefs_de_prevention_categorie?.length)
+                          <p class="mb-1 d-flex align-items-center gap-1">
+                            @svg('ph:scales-fill')
+                            {{ audience.chefs_de_prevention_categorie.join(', ') }}
+                          </p>
+                        @endif
+                        @if(audience.type_de_peine_pour_les_infractions_principales)
+                          <p class="mb-1 d-flex align-items-center gap-1">
+                            @svg('ph:gavel-fill')
+                            {{ audience.type_de_peine_pour_les_infractions_principales }}
+                          </p>
+                        @endif
+                      </div>
+                      @if (audience.fondement_de_la_relaxe || audience.collectif_d_action_ou_lutte?.length)
+                        <div class="d-flex flex-column align-items-start gap-2">
+                          @if (audience.fondement_de_la_relaxe)
+                            <span class="badge rounded-pill border text-secondary">
+                              {{ audience.fondement_de_la_relaxe }}
+                          </span>
+                          @endif
+                          @each(collectif in audience.collectif_d_action_ou_lutte)
+                            <span class="badge rounded-pill border text-secondary">
+                              {{ collectif }}
                         </span>
-                        @end
-                      </div>
-                    @endif
-                  </div>
+                          @end
+                        </div>
+                      @endif
+                    </div>
 
-                  <div class="col-lg-7 d-flex flex-column gap-2">
-                    <div class="row bg-gray rounded-3 p-3">
-                      <div class="col-lg-5 d-flex flex-column gap-1 px-0 mb-3 mb-lg-0">
-                        <h3 class="text-purple small d-flex align-items-center gap-1">
-                          @svg('ph:gavel-fill')
-                          Faits et chronologie
-                        </h3>
-                        <p class="small fw-normal mb-0">
-                          @if(audience.resume_de_l_audience)
-                            <em>"{{ audience.resume_de_l_audience }}"</em>
-                          @else
-                            Aucune information
-                          @endif
-                        </p>
+                    <div class="col-lg-7 d-flex flex-column gap-2">
+                      <div class="row bg-gray rounded-3 p-3">
+                        <div class="col-lg-5 d-flex flex-column gap-1 px-0 mb-3 mb-lg-0">
+                          <h3 class="text-purple small d-flex align-items-center gap-1">
+                            @svg('ph:gavel-fill')
+                            Faits et chronologie
+                          </h3>
+                          <p class="small fw-normal mb-0">
+                            @if(audience.resume_de_l_audience)
+                              <em>"{{ audience.resume_de_l_audience }}"</em>
+                            @else
+                              Aucune information
+                            @endif
+                          </p>
+                        </div>
+                        <div class="col-lg-7 d-flex justify-content-center justify-content-lg-end align-items-center">
+                          @!component('components/timeline', { data: audience.timeline, current: audience.id })
+                        </div>
                       </div>
-                      <div class="col-lg-7 d-flex justify-content-center justify-content-lg-end align-items-center">
-                        @!component('components/timeline', { data: audience.timeline, current: audience.id })
+                      <div class="row bg-gray rounded-3 p-3">
+                        <div class="col-12 d-flex flex-column gap-1 px-0">
+                          <h3 class="text-purple small d-flex align-items-center gap-1">
+                            <img class="summary-icon" src="{{ asset('resources/images/summary_icon.svg') }}" alt="summary icon" />Extrait de la décision
+                          </h3>
+                          <p class="small fw-normal mb-0">
+                            @if(audience.extrait_de_la_decision)
+                              <em>"{{ audience.extrait_de_la_decision }}"</em>
+                            @else
+                              Aucune information
+                            @endif
+                          </p>
+                        </div>
                       </div>
-                    </div>
-                    <div class="row bg-gray rounded-3 p-3">
-                      <div class="col-12 d-flex flex-column gap-1 px-0">
-                        <h3 class="text-purple small d-flex align-items-center gap-1">
-                          <img class="summary-icon" src="{{ asset('resources/images/summary_icon.svg') }}" alt="summary icon" />Extrait de la décision
-                        </h3>
-                        <p class="small fw-normal mb-0">
-                          @if(audience.extrait_de_la_decision)
-                            <em>"{{ audience.extrait_de_la_decision }}"</em>
-                          @else
-                            Aucune information
-                          @endif
-                        </p>
-                      </div>
-                    </div>
-                    <div class="row bg-gray rounded-3 p-3">
-                      <div class="col-12 d-flex flex-column gap-1 px-0">
-                        <h3 class="text-purple small d-flex align-items-center gap-1">
-                          <img
-                            class="msde-leaf-icon me-1"
-                            src="{{ asset('resources/images/msde_icon_purple.svg') }}"
-                            alt="msde leaf"
-                          />Commentaire MSDE
-                        </h3>
-                        <p class="small fw-normal mb-0">
-                          @if(audience.commentaire_msde)
-                            {{ audience.commentaire_msde }}
-                          @else
-                            Aucune information
-                          @endif
-                        </p>
+                      <div class="row bg-gray rounded-3 p-3">
+                        <div class="col-12 d-flex flex-column gap-1 px-0">
+                          <h3 class="text-purple small d-flex align-items-center gap-1">
+                            <img
+                              class="msde-leaf-icon me-1"
+                              src="{{ asset('resources/images/msde_icon_purple.svg') }}"
+                              alt="msde leaf"
+                            />Commentaire MSDE
+                          </h3>
+                          <p class="small fw-normal mb-0">
+                            @if(audience.commentaire_msde)
+                              {{ audience.commentaire_msde }}
+                            @else
+                              Aucune information
+                            @endif
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
+            </a>
           @end
         </div>
         <nav class="mt-3">

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -26,7 +26,10 @@ router
   .get('/audiences/:id/jugements/:jugementId', [AudiencesController, 'getJugementFile'])
   .as('audiences.jugements')
   .use(middleware.auth())
-router.get('/audiences/:id', [AudiencesController, 'get']).use(middleware.auth())
+router
+  .get('/audiences/:id', [AudiencesController, 'get'])
+  .as('audiences.show')
+  .use(middleware.auth())
 router.on('/sign-up').render('pages/auth/sign_up')
 router.on('/sign-in').render('pages/auth/sign_in').use(middleware.guest()).as('auth.sign_in')
 router.on('/change-password').render('pages/auth/change_password').use(middleware.auth())

--- a/tests/functional/search_audiences.spec.ts
+++ b/tests/functional/search_audiences.spec.ts
@@ -1,0 +1,77 @@
+import { ProcedureFactory } from '#database/factories/procedure_factory'
+import { AudienceService } from '#services/audience_service'
+import { test } from '@japa/runner'
+import { DateTime } from 'luxon'
+
+test.group('Search audiences', () => {
+  const services = new AudienceService()
+  test('search all audiences', async ({ assert }) => {
+    await ProcedureFactory.apply('publiee')
+      .with('audiences', 1, (audience) => audience.apply('publiee'))
+      .create()
+
+    const result = await services.searchAudiences({})
+
+    assert.properties(result.at(0), [
+      'appel_d_une_des_parties',
+      'chefs_de_prevention_categorie',
+      'chefs_de_prevention_sous_categorie',
+      'collectif_d_action_ou_lutte',
+      'commentaire_msde',
+      'date_de_decision',
+      'date_de_l_audience',
+      'date_des_faits',
+      'decision_et_peines_pour_les_infractions_subies_ou_incidentes',
+      'decision_pour_les_infractions_principales',
+      'degre_de_juridiction',
+      'demande_des_parties_civiles',
+      'detail_des_dommages_et_interets',
+      'details_de_la_decision_pour_les_infractions_principales',
+      'details_des_peines_pour_les_infractions_principales',
+      'dommages_et_interets',
+      'extrait_de_la_decision',
+      'faits_concis',
+      'faits_detailles',
+      'fondement_de_la_relaxe',
+      'id',
+      'inscription_au_casier_judiciaire',
+      'jugement_ou_arret',
+      'juridiction',
+      'mots_cles',
+      'nombre_de_prevenus',
+      'noms_des_parties_civiles',
+      'numero_de_chambre',
+      'partie_de_l_appel_incident',
+      'partie_de_l_appel_principal',
+      'plaidoirie_de_la_defense',
+      'publiee',
+      'recit_d_audience',
+      'reference_de_la_decision',
+      'reference_procedure',
+      'requisitions',
+      'resume_de_l_audience',
+      'resume_du_jugement_ou_arret',
+      'score_de_la_gravite',
+      'timeline',
+      'titre',
+      'type_de_peine_pour_les_infractions_principales',
+      'ville_de_l_audience',
+    ])
+
+    assert.isTrue(DateTime.isDateTime(result.at(0)?.date_des_faits))
+    assert.isTrue(DateTime.isDateTime(result.at(0)?.date_de_l_audience))
+    assert.isTrue(DateTime.isDateTime(result.at(0)?.date_de_decision))
+    assert.isArray(result.at(0)?.mots_cles)
+    assert.isArray(result.at(0)?.chefs_de_prevention_categorie)
+    assert.isArray(result.at(0)?.collectif_d_action_ou_lutte)
+
+    assert.isArray(result.at(0)?.timeline)
+    assert.isTrue(DateTime.isDateTime(result.at(0)?.timeline.at(0)?.date_de_decision))
+
+    assert.equal(result.total, 1)
+    assert.equal(result.lastPage, 1)
+    assert.equal(result.currentPage, 1)
+    assert.equal(result.perPage, 50)
+    assert.equal(result.firstPage, 1)
+  })
+})

--- a/tests/unit/timeline_mapper.spec.ts
+++ b/tests/unit/timeline_mapper.spec.ts
@@ -1,4 +1,8 @@
-import { TimelineDataMapper } from '#controllers/mappers/timeline_mapper'
+import {
+  TimelineAudienceAVenirItem,
+  TimelineAudienceItem,
+  TimelineDataMapper,
+} from '#controllers/mappers/timeline_mapper'
 import { test } from '@japa/runner'
 
 test.group('Timeline mapper algorithm', () => {
@@ -10,20 +14,21 @@ test.group('Timeline mapper algorithm', () => {
     degre_de_juridiction: testProperty,
   })
 
-  test('should return unaltered event objects', async ({ assert }) => {
+  test('should return unaltered event data', async ({ assert }) => {
     const text = 'This text should remain unaltered'
     const timeline = [mockEvent(1, '2020-01-01', text)]
-    const result = timelineDataMapper.map({ timeline, id: 1 })
-    assert.equal(result[0].id, 1)
-    assert.equal(result[0].degre_de_juridiction, text)
-    assert.equal(result[0].date_de_decision, '2020-01-01')
+    const result = timelineDataMapper.map({ timeline, id: 1, date_des_faits: null })
+    assert.equal(result[0].type, 'audience')
+    assert.equal((result[0] as TimelineAudienceItem).id, 1)
+    assert.equal((result[0] as TimelineAudienceItem).degre_de_juridiction, text)
+    assert.equal((result[0] as TimelineAudienceItem).date, '2020-01-01')
   })
 
-  test('should return all events when they are less than 4', ({ assert }) => {
+  test('should return all events when they are less than maximumNumberOfEvents', ({ assert }) => {
     const timeline = [mockEvent(1, '2024-01-10'), mockEvent(2, '2024-01-20')]
-    const result = timelineDataMapper.map({ timeline, id: 1 })
+    const result = timelineDataMapper.map({ timeline, id: 1, date_des_faits: null })
     assert.lengthOf(result, 2)
-    assert.equal(result[0].id, 1)
+    assert.equal((result[0] as TimelineAudienceItem).id, 1)
   })
 
   test('should move the current audience at prefered index (#1)', ({ assert }) => {
@@ -35,16 +40,33 @@ test.group('Timeline mapper algorithm', () => {
       mockEvent(5, '2024-05-01'),
     ]
 
-    const result = timelineDataMapper.map({ timeline, id: 3 })
+    const result = timelineDataMapper.map({ timeline, id: 3, date_des_faits: null })
 
     assert.lengthOf(result, 4, 'Timeline returned should contain 4 events')
-    assert.equal(result[1].id, 3, 'Current audience should be the second item (index 1)')
+    assert.equal(result[1].type, 'audience', 'Current audience should be a TimelineAudienceItem')
     assert.equal(
-      result[0].id,
+      (result[1] as TimelineAudienceItem).id,
+      3,
+      'Current audience should be the second item (index 1)'
+    )
+    assert.equal(result[0].type, 'audience', 'Past audience should be a TimelineAudienceItem')
+    assert.equal(
+      (result[0] as TimelineAudienceItem).id,
       2,
       'Timeline should have 1 past event in the first position(index 0)'
     )
-    assert.equal(result[3].id, 5, 'Timeline should contain 2 future events')
+    assert.equal(result[2].type, 'audience', 'Future audience should be a TimelineAudienceItem')
+    assert.equal(
+      (result[2] as TimelineAudienceItem).id,
+      4,
+      'Timeline should contain 1 future event in the third position (index 2)'
+    )
+    assert.equal(result[3].type, 'audience', 'Future audience should be a TimelineAudienceItem')
+    assert.equal(
+      (result[3] as TimelineAudienceItem).id,
+      5,
+      'Timeline should contain 1 future event in the fourth position (index 3)'
+    )
   })
 
   test('should handle when current date is the first event', ({ assert }) => {
@@ -55,16 +77,29 @@ test.group('Timeline mapper algorithm', () => {
       mockEvent(4, '2024-04-01'),
       mockEvent(5, '2024-05-01'),
     ]
-    const result = timelineDataMapper.map({ timeline, id: 1 })
+    const result = timelineDataMapper.map({ timeline, id: 1, date_des_faits: null })
     assert.lengthOf(result, 4)
-    assert.equal(result[0].id, 1, 'Current audience is the first because no past event')
+
+    assert.equal(result[0].type, 'audience', 'Current audience should be a TimelineAudienceItem')
+    assert.equal(
+      (result[0] as TimelineAudienceItem).id,
+      1,
+      'Current audience is the first because no past event'
+    )
   })
 
   test('should handle correctly empty dates', ({ assert }) => {
     const timeline = [mockEvent(1, '2024-01-01'), mockEvent(2), mockEvent(3, '2023-01-01')]
-    const result = timelineDataMapper.map({ timeline, id: 1 })
-    assert.equal(result[0].id, 3, '2023 should be first')
-    assert.equal(result[2].id, 2, 'Empry date should be the last (year 2199)')
+    const result = timelineDataMapper.map({ timeline, id: 1, date_des_faits: null })
+    assert.lengthOf(result, 3)
+    assert.equal(result[0].type, 'audience', 'First item should be a TimelineAudienceItem')
+    assert.equal((result[0] as TimelineAudienceItem).id, 3, '2023 should be first')
+    assert.equal(
+      result[2].type,
+      'audience_a_venir',
+      'Last item should be a TimelineAudienceAVenirItem'
+    )
+    assert.equal((result[2] as TimelineAudienceAVenirItem).id, 2, 'Empry date should be the last')
   })
 
   test('should return 4 events even if current is the last one', ({ assert }) => {
@@ -75,13 +110,139 @@ test.group('Timeline mapper algorithm', () => {
       mockEvent(4, '2024-04-01'),
       mockEvent(5, '2024-05-01'),
     ]
-    const result = timelineDataMapper.map({ timeline, id: 5 })
+    const result = timelineDataMapper.map({ timeline, id: 5, date_des_faits: null })
     assert.lengthOf(result, 4, 'Should fill with past events if no future events left')
   })
 
-  test('should return 1 event there is only one event', ({ assert }) => {
+  test('should return 1 event there is only one event and no date des faits', ({ assert }) => {
     const timeline = [mockEvent(1, '2024-01-01')]
-    const result = timelineDataMapper.map({ timeline, id: 1 })
+    const result = timelineDataMapper.map({ timeline, id: 1, date_des_faits: null })
     assert.lengthOf(result, 1)
+  })
+
+  test('should add date des faits at first position if provided', ({ assert }) => {
+    const timeline = [mockEvent(1, '2024-01-10')]
+    const result = timelineDataMapper.map({ timeline, id: 1, date_des_faits: '2019-01-01' })
+    assert.lengthOf(result, 2)
+    assert.equal(result[0].type, 'faits')
+    assert.equal(result[0].date, '2019-01-01')
+    assert.equal(result[1].type, 'audience')
+    assert.equal((result[1] as TimelineAudienceItem).id, 1)
+  })
+
+  test('should return 4 events max when date des faits is provided', ({ assert }) => {
+    const timeline = [
+      mockEvent(1, '2024-01-01'),
+      mockEvent(2, '2024-02-01'),
+      mockEvent(3, '2024-03-01'),
+      mockEvent(4, '2024-04-01'),
+      mockEvent(5, '2024-05-01'),
+    ]
+    const result = timelineDataMapper.map({ timeline, id: 4, date_des_faits: '2019-01-01' })
+    assert.lengthOf(result, 4, 'Should trim to maximumNumberOfEvents')
+    assert.equal(result[0].type, 'faits', 'First item should be date des faits')
+    assert.equal(result[0].date, '2019-01-01', 'Date des faits should be correct')
+    assert.equal(result[1].type, 'audience', 'Second item should be a past TimelineAudienceItem')
+    assert.equal(
+      (result[1] as TimelineAudienceItem).id,
+      3,
+      'Most recent past event should be in second position'
+    )
+    assert.equal(
+      result[2].type,
+      'audience',
+      'Third item should be the current TimelineAudienceItem'
+    )
+    assert.equal(
+      (result[2] as TimelineAudienceItem).id,
+      4,
+      'Third item should be the current event'
+    )
+    assert.equal(result[3].type, 'audience', 'Fourth item should be a future TimelineAudienceItem')
+    assert.equal(
+      (result[3] as TimelineAudienceItem).id,
+      5,
+      'Most recent future event should be in fourth position'
+    )
+  })
+
+  test('should add skipped_before and skipped_after count when audiences are skipped', ({
+    assert,
+  }) => {
+    const timeline = [
+      mockEvent(1, '2024-01-01'),
+      mockEvent(2, '2024-02-01'),
+      mockEvent(3, '2024-03-01'),
+      mockEvent(4, '2024-04-01'), //current audience
+      mockEvent(5, '2024-05-01'),
+      mockEvent(6, '2024-06-01'),
+      mockEvent(7, '2024-07-01'),
+      mockEvent(8, '2024-08-01'),
+    ]
+    const result = timelineDataMapper.map({ timeline, id: 4, date_des_faits: '2019-01-01' })
+    assert.lengthOf(result, 4, 'Should trim to maximumNumberOfEvents')
+    assert.equal(result[0].type, 'faits', 'First item should be date des faits')
+    assert.equal(result[1].type, 'audience', 'Second item should be a past TimelineAudienceItem')
+    assert.equal(
+      (result[1] as TimelineAudienceItem).skipped_before,
+      2,
+      'Second item should have skipped_before with the number of past events skipped'
+    )
+    assert.equal(
+      result[2].type,
+      'audience',
+      'Third item should be the current TimelineAudienceItem'
+    )
+    assert.equal(
+      (result[2] as TimelineAudienceItem).id,
+      4,
+      'Third item should be the current event'
+    )
+    assert.equal(
+      (result[3] as TimelineAudienceItem).id,
+      5,
+      'Most recent future event should be in fourth position'
+    )
+    assert.equal(
+      (result[3] as TimelineAudienceItem).skipped_after,
+      3,
+      'Fourth item should have skipped_after with the number of future events skipped'
+    )
+  })
+
+  test('should return older events first if current audience is not present', ({ assert }) => {
+    const timeline = [
+      mockEvent(1, '2024-01-01'),
+      mockEvent(2, '2025-05-01'),
+      mockEvent(3, '2024-03-01'),
+      mockEvent(4, '2026-02-01'),
+      mockEvent(5, '2024-04-01'),
+    ]
+    const result = timelineDataMapper.map({ timeline, id: 99, date_des_faits: '2019-01-01' })
+    assert.lengthOf(result, 4, 'Should trim to maximumNumberOfEvents')
+    assert.equal(result[0].type, 'faits', 'First item should be date des faits')
+    assert.equal(result[1].type, 'audience', 'Second item should be a TimelineAudienceItem')
+    assert.equal(
+      (result[1] as TimelineAudienceItem).id,
+      1,
+      'Second item should be the older past event'
+    )
+    assert.equal(result[2].type, 'audience', 'Third item should be a TimelineAudienceItem')
+    assert.equal(
+      (result[2] as TimelineAudienceItem).id,
+      3,
+      'Third item should be the second older past event'
+    )
+    assert.equal(result[3].type, 'audience', 'Last item should be a TimelineAudienceItem')
+    assert.equal(
+      (result[3] as TimelineAudienceItem).id,
+      5,
+      'Fourth item should be the third older past event'
+    )
+    assert.equal(
+      (result[3] as TimelineAudienceItem).skipped_after,
+      2,
+      'Fourth item should have skipped_after with the number of future events skipped'
+    )
   })
 })

--- a/tests/unit/timeline_mapper.spec.ts
+++ b/tests/unit/timeline_mapper.spec.ts
@@ -3,29 +3,43 @@ import {
   TimelineAudienceItem,
   TimelineDataMapper,
 } from '#controllers/mappers/timeline_mapper'
+import type { SearchAudiencesResponse } from '#services/audience_service'
 import { test } from '@japa/runner'
+import { DateTime } from 'luxon'
 
 test.group('Timeline mapper algorithm', () => {
   const timelineDataMapper = new TimelineDataMapper()
 
-  const mockEvent = (id: number, date?: string, testProperty?: string) => ({
+  const mockEvent = (
+    id: number,
+    date_de_decision: DateTime | null = null,
+    degre_de_juridiction: string | null = null,
+    decision_pour_les_infractions_principales: string | null = null,
+    type_de_peine_pour_les_infractions_principales: string | null = null
+  ): SearchAudiencesResponse[number]['timeline'][number] => ({
     id,
-    date_de_decision: date,
-    degre_de_juridiction: testProperty,
+    date_de_decision,
+    degre_de_juridiction,
+    decision_pour_les_infractions_principales,
+    type_de_peine_pour_les_infractions_principales,
+    publiee: true,
   })
 
   test('should return unaltered event data', async ({ assert }) => {
     const text = 'This text should remain unaltered'
-    const timeline = [mockEvent(1, '2020-01-01', text)]
+    const timeline = [mockEvent(1, DateTime.fromISO('2020-01-01'), text)]
     const result = timelineDataMapper.map({ timeline, id: 1, date_des_faits: null })
     assert.equal(result[0].type, 'audience')
     assert.equal((result[0] as TimelineAudienceItem).id, 1)
     assert.equal((result[0] as TimelineAudienceItem).degre_de_juridiction, text)
-    assert.equal((result[0] as TimelineAudienceItem).date, '2020-01-01')
+    assert.isTrue((result[0] as TimelineAudienceItem).date.equals(DateTime.fromISO('2020-01-01')))
   })
 
   test('should return all events when they are less than maximumNumberOfEvents', ({ assert }) => {
-    const timeline = [mockEvent(1, '2024-01-10'), mockEvent(2, '2024-01-20')]
+    const timeline = [
+      mockEvent(1, DateTime.fromISO('2024-01-10')),
+      mockEvent(2, DateTime.fromISO('2024-01-20')),
+    ]
     const result = timelineDataMapper.map({ timeline, id: 1, date_des_faits: null })
     assert.lengthOf(result, 2)
     assert.equal((result[0] as TimelineAudienceItem).id, 1)
@@ -33,11 +47,11 @@ test.group('Timeline mapper algorithm', () => {
 
   test('should move the current audience at prefered index (#1)', ({ assert }) => {
     const timeline = [
-      mockEvent(1, '2024-01-01'),
-      mockEvent(2, '2024-02-01'),
-      mockEvent(3, '2024-03-01'),
-      mockEvent(4, '2024-04-01'),
-      mockEvent(5, '2024-05-01'),
+      mockEvent(1, DateTime.fromISO('2024-01-01')),
+      mockEvent(2, DateTime.fromISO('2024-02-01')),
+      mockEvent(3, DateTime.fromISO('2024-03-01')),
+      mockEvent(4, DateTime.fromISO('2024-04-01')),
+      mockEvent(5, DateTime.fromISO('2024-05-01')),
     ]
 
     const result = timelineDataMapper.map({ timeline, id: 3, date_des_faits: null })
@@ -71,11 +85,11 @@ test.group('Timeline mapper algorithm', () => {
 
   test('should handle when current date is the first event', ({ assert }) => {
     const timeline = [
-      mockEvent(1, '2024-01-01'),
-      mockEvent(2, '2024-02-01'),
-      mockEvent(3, '2024-03-01'),
-      mockEvent(4, '2024-04-01'),
-      mockEvent(5, '2024-05-01'),
+      mockEvent(1, DateTime.fromISO('2024-01-01')),
+      mockEvent(2, DateTime.fromISO('2024-02-01')),
+      mockEvent(3, DateTime.fromISO('2024-03-01')),
+      mockEvent(4, DateTime.fromISO('2024-04-01')),
+      mockEvent(5, DateTime.fromISO('2024-05-01')),
     ]
     const result = timelineDataMapper.map({ timeline, id: 1, date_des_faits: null })
     assert.lengthOf(result, 4)
@@ -89,7 +103,11 @@ test.group('Timeline mapper algorithm', () => {
   })
 
   test('should handle correctly empty dates', ({ assert }) => {
-    const timeline = [mockEvent(1, '2024-01-01'), mockEvent(2), mockEvent(3, '2023-01-01')]
+    const timeline = [
+      mockEvent(1, DateTime.fromISO('2024-01-01')),
+      mockEvent(2),
+      mockEvent(3, DateTime.fromISO('2023-01-01')),
+    ]
     const result = timelineDataMapper.map({ timeline, id: 1, date_des_faits: null })
     assert.lengthOf(result, 3)
     assert.equal(result[0].type, 'audience', 'First item should be a TimelineAudienceItem')
@@ -104,44 +122,55 @@ test.group('Timeline mapper algorithm', () => {
 
   test('should return 4 events even if current is the last one', ({ assert }) => {
     const timeline = [
-      mockEvent(1, '2024-01-01'),
-      mockEvent(2, '2024-02-01'),
-      mockEvent(3, '2024-03-01'),
-      mockEvent(4, '2024-04-01'),
-      mockEvent(5, '2024-05-01'),
+      mockEvent(1, DateTime.fromISO('2024-01-01')),
+      mockEvent(2, DateTime.fromISO('2024-02-01')),
+      mockEvent(3, DateTime.fromISO('2024-03-01')),
+      mockEvent(4, DateTime.fromISO('2024-04-01')),
+      mockEvent(5, DateTime.fromISO('2024-05-01')),
     ]
     const result = timelineDataMapper.map({ timeline, id: 5, date_des_faits: null })
     assert.lengthOf(result, 4, 'Should fill with past events if no future events left')
   })
 
   test('should return 1 event there is only one event and no date des faits', ({ assert }) => {
-    const timeline = [mockEvent(1, '2024-01-01')]
+    const timeline = [mockEvent(1, DateTime.fromISO('2024-01-01'))]
     const result = timelineDataMapper.map({ timeline, id: 1, date_des_faits: null })
     assert.lengthOf(result, 1)
   })
 
   test('should add date des faits at first position if provided', ({ assert }) => {
-    const timeline = [mockEvent(1, '2024-01-10')]
-    const result = timelineDataMapper.map({ timeline, id: 1, date_des_faits: '2019-01-01' })
+    const timeline = [mockEvent(1, DateTime.fromISO('2024-01-10'))]
+    const result = timelineDataMapper.map({
+      timeline,
+      id: 1,
+      date_des_faits: DateTime.fromISO('2019-01-01'),
+    })
     assert.lengthOf(result, 2)
     assert.equal(result[0].type, 'faits')
-    assert.equal(result[0].date, '2019-01-01')
+    assert.isTrue(result[0].date!.equals(DateTime.fromISO('2019-01-01')))
     assert.equal(result[1].type, 'audience')
     assert.equal((result[1] as TimelineAudienceItem).id, 1)
   })
 
   test('should return 4 events max when date des faits is provided', ({ assert }) => {
     const timeline = [
-      mockEvent(1, '2024-01-01'),
-      mockEvent(2, '2024-02-01'),
-      mockEvent(3, '2024-03-01'),
-      mockEvent(4, '2024-04-01'),
-      mockEvent(5, '2024-05-01'),
+      mockEvent(1, DateTime.fromISO('2024-01-01')),
+      mockEvent(2, DateTime.fromISO('2024-02-01')),
+      mockEvent(3, DateTime.fromISO('2024-03-01')),
+      mockEvent(4, DateTime.fromISO('2024-04-01')),
+      mockEvent(5, DateTime.fromISO('2024-05-01')),
     ]
-    const result = timelineDataMapper.map({ timeline, id: 4, date_des_faits: '2019-01-01' })
+    const result = timelineDataMapper.map({
+      timeline,
+      id: 4,
+      date_des_faits: DateTime.fromISO('2019-01-01'),
+    })
     assert.lengthOf(result, 4, 'Should trim to maximumNumberOfEvents')
     assert.equal(result[0].type, 'faits', 'First item should be date des faits')
-    assert.equal(result[0].date, '2019-01-01', 'Date des faits should be correct')
+    assert.isTrue(
+      result[0].date!.equals(DateTime.fromISO('2019-01-01')),
+      'Date des faits should be correct'
+    )
     assert.equal(result[1].type, 'audience', 'Second item should be a past TimelineAudienceItem')
     assert.equal(
       (result[1] as TimelineAudienceItem).id,
@@ -170,16 +199,20 @@ test.group('Timeline mapper algorithm', () => {
     assert,
   }) => {
     const timeline = [
-      mockEvent(1, '2024-01-01'),
-      mockEvent(2, '2024-02-01'),
-      mockEvent(3, '2024-03-01'),
-      mockEvent(4, '2024-04-01'), //current audience
-      mockEvent(5, '2024-05-01'),
-      mockEvent(6, '2024-06-01'),
-      mockEvent(7, '2024-07-01'),
-      mockEvent(8, '2024-08-01'),
+      mockEvent(1, DateTime.fromISO('2024-01-01')),
+      mockEvent(2, DateTime.fromISO('2024-02-01')),
+      mockEvent(3, DateTime.fromISO('2024-03-01')),
+      mockEvent(4, DateTime.fromISO('2024-04-01')), //current audience
+      mockEvent(5, DateTime.fromISO('2024-05-01')),
+      mockEvent(6, DateTime.fromISO('2024-06-01')),
+      mockEvent(7, DateTime.fromISO('2024-07-01')),
+      mockEvent(8, DateTime.fromISO('2024-08-01')),
     ]
-    const result = timelineDataMapper.map({ timeline, id: 4, date_des_faits: '2019-01-01' })
+    const result = timelineDataMapper.map({
+      timeline,
+      id: 4,
+      date_des_faits: DateTime.fromISO('2019-01-01'),
+    })
     assert.lengthOf(result, 4, 'Should trim to maximumNumberOfEvents')
     assert.equal(result[0].type, 'faits', 'First item should be date des faits')
     assert.equal(result[1].type, 'audience', 'Second item should be a past TimelineAudienceItem')
@@ -212,13 +245,17 @@ test.group('Timeline mapper algorithm', () => {
 
   test('should return older events first if current audience is not present', ({ assert }) => {
     const timeline = [
-      mockEvent(1, '2024-01-01'),
-      mockEvent(2, '2025-05-01'),
-      mockEvent(3, '2024-03-01'),
-      mockEvent(4, '2026-02-01'),
-      mockEvent(5, '2024-04-01'),
+      mockEvent(1, DateTime.fromISO('2024-01-01')),
+      mockEvent(2, DateTime.fromISO('2025-05-01')),
+      mockEvent(3, DateTime.fromISO('2024-03-01')),
+      mockEvent(4, DateTime.fromISO('2026-02-01')),
+      mockEvent(5, DateTime.fromISO('2024-04-01')),
     ]
-    const result = timelineDataMapper.map({ timeline, id: 99, date_des_faits: '2019-01-01' })
+    const result = timelineDataMapper.map({
+      timeline,
+      id: 99,
+      date_des_faits: DateTime.fromISO('2019-01-01'),
+    })
     assert.lengthOf(result, 4, 'Should trim to maximumNumberOfEvents')
     assert.equal(result[0].type, 'faits', 'First item should be date des faits')
     assert.equal(result[1].type, 'audience', 'Second item should be a TimelineAudienceItem')


### PR DESCRIPTION
Issue #141 

- Rendre cliquable la carte de résultat
- Les éléments de la timeline ne sont plus cliquable
- Mise à jour algo pour intégrer la date des faits
  -  Typage du résultat de la requête SQL : `TimelineDbResultItem` qui diffère de celui créé par le mapper : `TimelineItem`
  - Utilisation d'une union discriminative avec l'attribut `type` qui permet de savoir si l'element de la timeline est la date des faits, une audience avec date ou une audience à venir (surtout utile pour la date des faits qui n'a pas les memes attributs que les audiences). Cette union de type définit une propriété `date` commune et agnostique.
  - Calcul du nombre d'audiences non affichés avant ou après par rapport à une audience
  - Ajout de tests unitaires associés
- Mise à jour template timeline
  - Ajout du nombre d'audiences non affichés sous forme de bulles avec la classe `timeline-node-skipped` et les data attributes `data-skipped-before` et `data-skipped-after`
  - Ajout d'un bout de ligne avant le début de la timeline pour indiquer le passé

Correctifs :
-  Correction du wording sur la carte "aucun résultat", il fallait utiliser un point médian sur `militant⋅es`
- Ajout du compte de filtres sur le bouton "Plus de filtres", auparavant il était à l'extérieur

Notes : 
- Sur cette version, pour plus de simplicité, on force la position de la date des faits en première position, on ne teste pas que cette date est bien la première chronologiquement
- On a géré le fait qu'elle pouvait être absente, dans ce cas l'ancien algo fonctionne toujours