### PR TITLE
feat: add audience graph in detail page

### DIFF
--- a/app/controllers/audiences_controller.ts
+++ b/app/controllers/audiences_controller.ts
@@ -1,8 +1,10 @@
 import { AudienceService } from '#services/audience_service'
 import { NocodbService } from '#services/nocodb_service'
 import { ProcedureService } from '#services/procedure_service'
+import env from '#start/env'
 import { inject } from '@adonisjs/core'
 import type { HttpContext } from '@adonisjs/core/http'
+import jwt from 'jsonwebtoken'
 import { Readable } from 'node:stream'
 
 @inject()
@@ -34,11 +36,25 @@ export default class AudiencesController {
 
     const lastDecision = this.audienceService.getLastDecision(procedureWithAudiences.audiences)
 
+    //TODO: fetch dashboard like in analyses but specifying the type audience ?
+    const metabaseToken = jwt.sign(
+      {
+        resource: { question: 102 },
+        params: {
+          // chefs_de_prevention_categorie: audience?.chefs_de_prevention_categorie || [],
+          audience_id: [audience?.id],
+        },
+        exp: Math.round(Date.now() / 1000) + 2 * 60, // 2 minute expiration
+      },
+      env.get('METABASE_SECRET_KEY')
+    )
+
     return view.render('pages/audience', {
       procedure: procedureWithAudiences,
       currentAudience: audience,
       liensPresse,
       lastDecision,
+      metabaseToken,
     })
   }
 

--- a/app/controllers/audiences_controller.ts
+++ b/app/controllers/audiences_controller.ts
@@ -1,4 +1,5 @@
 import { AudienceService } from '#services/audience_service'
+import { ConfigurationService } from '#services/configuration_service'
 import { NocodbService } from '#services/nocodb_service'
 import { ProcedureService } from '#services/procedure_service'
 import env from '#start/env'
@@ -10,9 +11,10 @@ import { Readable } from 'node:stream'
 @inject()
 export default class AudiencesController {
   constructor(
-    public audienceService: AudienceService,
-    public procedureService: ProcedureService,
-    public nocodbService: NocodbService
+    private readonly audienceService: AudienceService,
+    private readonly procedureService: ProcedureService,
+    private readonly nocodbService: NocodbService,
+    private readonly configurationService: ConfigurationService
   ) {}
 
   /**
@@ -29,25 +31,26 @@ export default class AudiencesController {
     const audience = procedureWithAudiences.audiences.find(
       (a) => a.id === Number(request.param('id'))
     )
-    const liensPresse = [
-      ...(procedureWithAudiences.la_presse_parle_des_faits ?? []),
-      ...procedureWithAudiences.audiences.flatMap((a) => a.la_presse_parle_du_proces ?? []),
-    ].sort((a, b) => a.titre.localeCompare(b.titre))
+    const liensPresse = procedureWithAudiences.la_presse_parle_des_faits
+      .concat(procedureWithAudiences.audiences.flatMap((a) => a.la_presse_parle_du_proces))
+      .sort((a, b) => a.titre.localeCompare(b.titre))
 
     const lastDecision = this.audienceService.getLastDecision(procedureWithAudiences.audiences)
 
-    //TODO: fetch dashboard like in analyses but specifying the type audience ?
-    const metabaseToken = jwt.sign(
-      {
-        resource: { question: 102 },
-        params: {
-          // chefs_de_prevention_categorie: audience?.chefs_de_prevention_categorie || [],
-          audience_id: [audience?.id],
-        },
-        exp: Math.round(Date.now() / 1000) + 2 * 60, // 2 minute expiration
-      },
-      env.get('METABASE_SECRET_KEY')
-    )
+    const question = await this.configurationService.audienceGraphique()
+
+    const metabaseToken = question
+      ? jwt.sign(
+          {
+            resource: { question },
+            params: {
+              audience_id: [audience?.id],
+            },
+            exp: Math.round(Date.now() / 1000) + 2 * 60, // 2 minute expiration
+          },
+          env.get('METABASE_SECRET_KEY')
+        )
+      : null
 
     return view.render('pages/audience', {
       procedure: procedureWithAudiences,

--- a/app/models/configuration.ts
+++ b/app/models/configuration.ts
@@ -1,0 +1,12 @@
+import { BaseModel, column } from '@adonisjs/lucid/orm'
+
+export default class Configuration extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare name: string
+
+  @column()
+  declare value: string
+}

--- a/app/services/configuration_service.ts
+++ b/app/services/configuration_service.ts
@@ -1,0 +1,11 @@
+import Configuration from '#models/configuration'
+
+export class ConfigurationService {
+  /**
+   * This value define the question id of the metabase question used to display the audience graphique.
+   */
+  async audienceGraphique() {
+    const config = await Configuration.findBy('name', 'audience_graphique')
+    return config ? Number(config.value) : null
+  }
+}

--- a/app/services/configuration_service.ts
+++ b/app/services/configuration_service.ts
@@ -6,6 +6,7 @@ export class ConfigurationService {
    */
   async audienceGraphique() {
     const config = await Configuration.findBy('name', 'audience_graphique')
-    return config ? Number(config.value) : null
+    const questionId = config ? Number.parseInt(config.value) : null
+    return Number.isInteger(questionId) ? questionId : null
   }
 }

--- a/database/migrations/1777038597373_create_configurations_table.ts
+++ b/database/migrations/1777038597373_create_configurations_table.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'configurations'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name').unique().notNullable()
+      table.string('value')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/resources/views/pages/audience.edge
+++ b/resources/views/pages/audience.edge
@@ -303,26 +303,17 @@
               </div>
             </div>
             @if(metabaseToken)
-              <div class="row g-5">
-                <section class="col-lg-12" aria-labelledby="graph-evolution-condamnations-heading">
-                  <h3 class="small" id="graph-evolution-condamnations-heading">
-                    Évolution des condamnations pour ce chef de prévention
-                  </h3>
-                  <p class="small">
-                    En france, entre 2014 et 2026 <span class="small text-muted">Le score de gravité est un indice MSDE. En savoir plus</span>
-                  </p>
-                  @let(initialParameters = {
-                  chefs_de_prevention_categorie: currentAudience.chefs_de_prevention_categorie
-                  })
-                  <metabase-question
-                    token="{{ metabaseToken }}"
-                    with-title="false"
-                    initial-sql-parameters='{{{ JSON.stringify(initialParameters) }}}'
-                    {{-- initial-sql-parameters='{"chefs_de_prevention_categorie":["Entrave à la circulation"]}' --}}
-                  >
-                  </metabase-question>
-                </section>
-              </div>
+              <section class="rounded border p-4" aria-labelledby="graph-evolution-condamnations-heading">
+                <h3 class="small" id="graph-evolution-condamnations-heading">
+                  Évolution des condamnations pour ce chef de prévention
+                </h3>
+                <p class="small">
+                  <!--TODO: handle En savoir plus link or remove + check if title should remain static -->
+                  En france, entre 2014 et 2026 <span class="small text-muted">Le score de gravité est un indice MSDE. En savoir plus</span>
+                </p>
+                <metabase-question token="{{ metabaseToken }}" with-title="false">
+                </metabase-question>
+              </section>
             @endif
             <div class="row g-5">
               <section class="col-12 vstack gap-3" aria-labelledby="section-informations-generales-heading">

--- a/resources/views/pages/audience.edge
+++ b/resources/views/pages/audience.edge
@@ -302,26 +302,28 @@
                 </section>
               </div>
             </div>
-            <div class="row g-5">
-              <section class="col-lg-12" aria-labelledby="graph-evolution-condamnations-heading">
-                <h3 class="small" id="graph-evolution-condamnations-heading">
-                  Évolution des condamnations pour ce chef de prévention
-                </h3>
-                <p class="small">
-                  En france, entre 2014 et 2026 <span class="small text-muted">Le score de gravité est un indice MSDE. En savoir plus</span>
-                </p>
-                @let(initialParameters = {
-                chefs_de_prevention_categorie: currentAudience.chefs_de_prevention_categorie
-                })
-                <metabase-question
-                  token="{{ metabaseToken }}"
-                  with-title="false"
-                  initial-sql-parameters='{{{ JSON.stringify(initialParameters) }}}'
-                  {{-- initial-sql-parameters='{"chefs_de_prevention_categorie":["Entrave à la circulation"]}' --}}
-                >
-                </metabase-question>
-              </section>
-            </div>
+            @if(metabaseToken)
+              <div class="row g-5">
+                <section class="col-lg-12" aria-labelledby="graph-evolution-condamnations-heading">
+                  <h3 class="small" id="graph-evolution-condamnations-heading">
+                    Évolution des condamnations pour ce chef de prévention
+                  </h3>
+                  <p class="small">
+                    En france, entre 2014 et 2026 <span class="small text-muted">Le score de gravité est un indice MSDE. En savoir plus</span>
+                  </p>
+                  @let(initialParameters = {
+                  chefs_de_prevention_categorie: currentAudience.chefs_de_prevention_categorie
+                  })
+                  <metabase-question
+                    token="{{ metabaseToken }}"
+                    with-title="false"
+                    initial-sql-parameters='{{{ JSON.stringify(initialParameters) }}}'
+                    {{-- initial-sql-parameters='{"chefs_de_prevention_categorie":["Entrave à la circulation"]}' --}}
+                  >
+                  </metabase-question>
+                </section>
+              </div>
+            @endif
             <div class="row g-5">
               <section class="col-12 vstack gap-3" aria-labelledby="section-informations-generales-heading">
                 <h3 id="section-informations-generales-heading" class="h5 fw-semibold mb-0">

--- a/resources/views/pages/audience.edge
+++ b/resources/views/pages/audience.edge
@@ -9,6 +9,23 @@
     </title>
     @let (navbarTheme = 'dark')
     @include('partials/bootstrap')
+    <script defer src="{{ env.get('METABASE_URL') }}/app/embed.js">
+
+    </script>
+    <script>
+      function defineMetabaseConfig(config) {
+        window.metabaseConfig = config;
+      }
+    </script>
+    <script>
+      defineMetabaseConfig({
+        theme: {
+          preset: "light"
+        },
+        isGuest: true,
+        instanceUrl: "{{ env.get('METABASE_URL') }}"
+      });
+    </script>
   </head>
 
   <body class="bg-light">
@@ -284,6 +301,26 @@
                   </hgroup>
                 </section>
               </div>
+            </div>
+            <div class="row g-5">
+              <section class="col-lg-12" aria-labelledby="graph-evolution-condamnations-heading">
+                <h3 class="small" id="graph-evolution-condamnations-heading">
+                  Évolution des condamnations pour ce chef de prévention
+                </h3>
+                <p class="small">
+                  En france, entre 2014 et 2026 <span class="small text-muted">Le score de gravité est un indice MSDE. En savoir plus</span>
+                </p>
+                @let(initialParameters = {
+                chefs_de_prevention_categorie: currentAudience.chefs_de_prevention_categorie
+                })
+                <metabase-question
+                  token="{{ metabaseToken }}"
+                  with-title="false"
+                  initial-sql-parameters='{{{ JSON.stringify(initialParameters) }}}'
+                  {{-- initial-sql-parameters='{"chefs_de_prevention_categorie":["Entrave à la circulation"]}' --}}
+                >
+                </metabase-question>
+              </section>
             </div>
             <div class="row g-5">
               <section class="col-12 vstack gap-3" aria-labelledby="section-informations-generales-heading">


### PR DESCRIPTION
Issue #165 

- [x] Intégration d'un graph avec id et titre statique dans l'appli (POC)
  - On cache le titre par défaut pour afficher un titre plus élaboré pour faire comme sur le figma 
  - On passe un paramètre "bloqué" lors de la création du token signé
  - On passe un paramètre SQL initial de filtre visible au composant `metabase-question` 
  - En discussion sur le blocage de l'un ou l'autre de ces paramètres
- [ ] Rendre l'intégration plus dynamique comme les dashboard
  - Egalement voir pour la partie titre qui selon la maquette figma est plus élaborée (titre, sous titre, lien) 

Note : 
- Exemple de l'interface sur l'issue initiale en commentaires.
- Impossible de cacher le bouton de téléchargement sur la version gratuite : 
https://www.metabase.com/docs/v0.58/embedding/guest-embedding#:~:text=%2A%20Disabling%20downloads%20is%20only%20available%20on%20Pro%20and%20Enterprise%20plans