### PR TITLE
fix: missing faits_concits in search result

### DIFF
--- a/resources/views/pages/home.edge
+++ b/resources/views/pages/home.edge
@@ -156,8 +156,8 @@
                             Faits et chronologie
                           </h3>
                           <p class="small fw-normal mb-0">
-                            @if(audience.resume_de_l_audience)
-                              <em>"{{ audience.resume_de_l_audience }}"</em>
+                            @if(audience.faits_concis)
+                              <em>"{{ audience.faits_concis }}"</em>
                             @else
                               Aucune information
                             @endif


### PR DESCRIPTION
Issue : N/A

Sur le résultat de recherche pour le champ "Faits et chronologie" on affichait le résumé de l'audience.
=> Il fallait afficher les faits concis de la procédure