### PR TITLE
feat: add longPragraphe edge component

### DIFF
--- a/resources/views/components/long_paragraphe.edge
+++ b/resources/views/components/long_paragraphe.edge
@@ -1,0 +1,83 @@
+@pushOnceTo('components')
+  <style>
+    .long-text {
+      --collapse-size: 14em;
+    }
+    
+    .long-text .btn {
+      border-radius: 24px;
+      border: 1px solid var(--relx-green-300);
+      background-color: var(--relx-green-100);
+      color: var(--relx-green-900);
+      font-size: 13px;
+      padding: 8px 20px 8px 20px;
+    }
+    
+    .long-text .blur {
+      display: flex;
+      justify-content: center;
+    }
+    
+    .long-text .blur .btn {
+      align-self: center;
+    }
+    
+    p.collapse:not(.show) {
+      display: inherit;
+      overflow: hidden;
+      height: var(--collapse-size);
+    }
+    
+    p.collapse:not(.show) + .blur {
+      position: absolute;
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgb(255, 255, 255) 100%);
+      height: 6em;
+      width: 100%;
+      bottom: 0;
+      opacity: 1;
+      transition: opacity .35s ease, bottom .15s ease;
+    }
+    
+    p.collapsing {
+      height: var(--collapse-size);
+    }
+    
+    p.collapsing + .blur {
+      position: absolute;
+      height: 0;
+      width: 100%;
+      bottom: 0px;
+      opacity: 0;
+      transition: opacity .35s ease, bottom .15s ease;
+    }
+    
+    p.collapsing + .blur .btn.reduce,
+    p.collapsing + .blur .btn.expend,
+    p.collapse:not(.show) + .blur .btn.reduce,
+    p.collapse.show + .blur .btn.expend {
+      display: none;
+    }
+  </style>
+@end
+
+<div class="position-relative long-text">
+  <p id="{{ id }}" class="collapse">
+    {{{ await $slots.text() }}}
+  </p>
+  <div class="blur">
+    <button
+      class="btn btn-secondary expend"
+      data-bs-toggle="collapse"
+      data-bs-target="#{{ id }}"
+      aria-controls="{{ id }}"
+      aria-expanded="false"
+    >Voir le résumé complet</button>
+    <button
+      class="btn btn-secondary reduce"
+      data-bs-toggle="collapse"
+      data-bs-target="#{{ id }}"
+      aria-controls="{{ id }}"
+      aria-expanded="false"
+    >Réduire</button>
+  </div>
+</div>

--- a/resources/views/components/long_paragraphe.edge
+++ b/resources/views/components/long_paragraphe.edge
@@ -35,7 +35,13 @@
       width: 100%;
       bottom: 0;
       opacity: 1;
-      transition: opacity .35s ease, bottom .15s ease;
+      transition: opacity .35s ease, height .15s linear;
+    }
+    
+    p.collapse.show + .blur {
+      opacity: 1;
+      height: 40px;
+      transition: opacity .35s ease, height .15s ease-out;
     }
     
     p.collapsing {
@@ -44,11 +50,12 @@
     
     p.collapsing + .blur {
       position: absolute;
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgb(255, 255, 255) 100%);
       height: 0;
       width: 100%;
-      bottom: 0px;
+      bottom: 0;
       opacity: 0;
-      transition: opacity .35s ease, bottom .15s ease;
+      transition: opacity .35s ease, height .15s linear;
     }
     
     p.collapsing + .blur .btn.reduce,

--- a/resources/views/design_system/design_system.edge
+++ b/resources/views/design_system/design_system.edge
@@ -73,6 +73,23 @@
 
       <div class="row">
         <h2 class="gelica">
+          Long paragraphe
+        </h2>
+        <div class="col-12">
+          @longParagraphe({ id: 'resume_de_l_audience' })
+            @slot('text')
+              Lors de l'audience, le prévenu répondait en turc à l’oreille d'un traducteur. Ce dernier répondait ensuite en français à la présidente. Le prévenu a commencé par dire qu'il agissait ainsi pour défendre l'environnement : "Ce projet, ce n'est pas comme on le dit, ce n'est pas du tout un projet vert, écologique, c'est un mensonge. C'est un projet qui menace l'écosystème de Bordeaux jusqu'à Capbreton, jusqu'à l'océan jusqu'au Pays basque. C'est un projet qui menace gravement l'écosystème, c'est un projet qui peut causer des catastrophes naturelles. L'écosystème est déjà en crise énorme. Nous partons vers une catastrophe générale écologique." a-t-il affirmé. Concernant le fait d'avoir jeté des sacs remplis de ses excréments, il a affirmé que c'était moins sales que les travaux de la ligne THT, que c'était pour lui une façon de s'exprimer, et de répondre à ce qu'il percevait comment une provocation de la part des ouvriers qui venaient sur le chantier avec leurs engins, les engins de chantier étant le symbole même du chantier.<br />
+              Lors de l'examen de sa personnalité, il a été mis en lumière qu'il avait déjà milité dans son pays, en Turquie et également dans le cadre de la lutte A69.<br />
+              Les avocat⋅es des parties civiles ont affirmé que le projet avait été déclaré d'utilité publique et qu'au jour de l'audience, bien que des recours juridiques aient été mis en oeuvre, aucune décision de justice ne condamne ce projet. Ils et elles n'ont pas hésité à parler de violences et de "pression psychologique sur les intervenants du chantier. Les parties civiles ont réclamé environ 110 000€ de dommages et intérêts, les justifiant notamment par les journées de travail empêchées par les descentes régulières en rappel du prévenu, et par le nettoyage des excréments.<br />
+              Le parquet a requis la condamnation du prévenu à 1000€ d'amende avec sursis, affirmant qu'"on ne peut pas commettre un délit au motif de ses convictions personnelles" et que "la liberté d'expression ne justifie pas une infraction". Le parquet a ajouté que le jet d'excrément constituait une voie de fait car cela a empêché les ouvriers de travailler (en raison de la nécessité de nettoyer les engins), n'hésitant pas également à parler d"acte violent" à ce propos : "On peut le prendre à mon sens sous les deux volets" a affirmé la procureure.<br />
+              L'avocate de la défense a plaidé l'état de nécessité à titre principal et la liberté d'expression à titre subsidaire. Elle a rappelé que le projet avait été condamné par la cour d'appel de Pau ce qui avait conduit à la suspension des travaux pendant 4 mois jusqu'à la mise en conformité et que de nombreuses actions citoyennes avaient été réalisées pour s'opposer à ce projet. Concernant le montant des dommages et intérêts, l'avocate a rappelé que dans le cadre d'une agression sexuelle, c'était 10 000€ qui étaient réclamés "Là on est sur un chantier qui dure des années. Une agression sexuelle cela dure toute une vie, comment on peut demander autant pour cette action aussi " et dénonçant l'absence de pièces pour justifier les montants réclamés. Et de conclure : "Madame la magistrate, beaucoup de magistrats ont montré la voie sur les mêmes fondements. Cette action est légitime et permet de sauvegarder un intérêt largement supérieur. Et je vous demande de faire ce pas en avant et de relaxer. C'est comme ça que vous pouvez protéger la démocratie"
+            @end
+          @end
+        </div>
+      </div>
+
+      <div class="row">
+        <h2 class="gelica">
           Boutons
         </h2>
 

--- a/resources/views/design_system/design_system.edge
+++ b/resources/views/design_system/design_system.edge
@@ -107,11 +107,11 @@
         </h2>
 
         <div class="col-12 col-md-6 col-lg-4">
-          @!component('components/multi_select', {
-          name: 'Prévention',
-          label: 'Prévention',
-          options: ['Vol Simple', 'Menace de mort', 'Escroquerie', 'Fraude ficale', 'Délit de fuite'],
-          selected: []
+          @!multiSelect({
+            name: 'Prévention',
+            label: 'Prévention',
+            options: ['Vol Simple', 'Menace de mort', 'Escroquerie', 'Fraude ficale', 'Délit de fuite'],
+            selected: []
           })
         </div>
 
@@ -123,10 +123,10 @@
         </h2>
 
         <div class="col-12 col-md-6 col-lg-4">
-          @!component('components/date_range_picker', {
-          name: 'dateDesFaits',
-          label: 'Date des faits',
-          value: ["2000-01-01", "2000-01-31"]
+          @!dateRangePicker({
+            name: 'dateDesFaits',
+            label: 'Date des faits',
+            value: ["2000-01-01", "2000-01-31"]
           })
         </div>
 

--- a/resources/views/pages/audience.edge
+++ b/resources/views/pages/audience.edge
@@ -343,7 +343,11 @@
                   </h4>
                   <p class="mb-0">
                     @if (audience.resume_de_l_audience)
-                      {{{ nl2br(audience.resume_de_l_audience) }}}
+                      @longParagraphe({ id: 'resume_de_l_audience' })
+                        @slot('text')
+                          {{{ nl2br(audience.resume_de_l_audience) }}}
+                        @end
+                      @end
                     @else
                       @!emptyData()
                     @endif

--- a/resources/views/pages/audience.edge
+++ b/resources/views/pages/audience.edge
@@ -102,7 +102,7 @@
                 @heroSection({titre: 'Détails des faits', icon: 'ph:folder-open'})
                   <p class="mb-0 small">
                     @if (procedure.faits_detailles)
-                      {{ procedure.faits_detailles }}
+                      {{{ nl2br(procedure.faits_detailles) }}}
                     @else
                       @!emptyData()
                     @endif
@@ -113,7 +113,7 @@
                 @heroSection({titre: 'Poursuites', icon: 'ph:scales'})
                   <p class="mb-0 small">
                     @if (procedure.poursuites)
-                      {{ procedure.poursuites }}
+                      {{{ nl2br(procedure.poursuites) }}}
                     @else
                       @!emptyData()
                     @endif
@@ -224,7 +224,7 @@
                   </h3>
                   <p class="mb-0">
                     @if (audience.details_de_la_decision_pour_les_infractions_principales)
-                      {{ audience.details_de_la_decision_pour_les_infractions_principales }}
+                      {{{ nl2br(audience.details_de_la_decision_pour_les_infractions_principales) }}}
                     @else
                       <span class="fst-italic text-muted">La décision n'a pas encore été rendue publique.</span>
                     @endif
@@ -343,7 +343,7 @@
                   </h4>
                   <p class="mb-0">
                     @if (audience.resume_de_l_audience)
-                      {{ audience.resume_de_l_audience }}
+                      {{{ nl2br(audience.resume_de_l_audience) }}}
                     @else
                       @!emptyData()
                     @endif
@@ -422,7 +422,7 @@
                   </dt>
                   <dd class="col-sm-9">
                     @if (audience.plaidoirie_de_la_defense)
-                      {{ audience.plaidoirie_de_la_defense }}
+                      {{{ nl2br(audience.plaidoirie_de_la_defense) }}}
                     @else
                       @!emptyData()
                     @endif
@@ -439,7 +439,7 @@
                   </dt>
                   <dd class="col-sm-9">
                     @if (audience.requisitions)
-                      {{ audience.requisitions }}
+                      {{{ nl2br(audience.requisitions) }}}
                     @else
                       @!emptyData()
                     @endif
@@ -459,7 +459,7 @@
                   </dt>
                   <dd class="col-sm-9">
                     @if (audience.demande_des_parties_civiles)
-                      {{ audience.demande_des_parties_civiles }}
+                      {{{ nl2br(audience.demande_des_parties_civiles) }}}
                     @else
                       @!emptyData()
                     @endif
@@ -506,7 +506,7 @@
                   </dt>
                   <dd class="col-sm-9">
                     @if (audience.details_de_la_decision_pour_les_infractions_principales)
-                      {{ audience.details_de_la_decision_pour_les_infractions_principales }}
+                      {{{ nl2br(audience.details_de_la_decision_pour_les_infractions_principales) }}}
                     @else
                       @!emptyData()
                     @endif
@@ -516,7 +516,7 @@
                   </dt>
                   <dd class="col-sm-9">
                     @if (audience.details_des_peines_pour_les_infractions_principales)
-                      {{ audience.details_des_peines_pour_les_infractions_principales }}
+                      {{{ nl2br(audience.details_des_peines_pour_les_infractions_principales) }}}
                     @else
                       @!emptyData()
                     @endif
@@ -547,7 +547,7 @@
                   <dd class="col-sm-9">
                     @if (audience.dommages_et_interets === true)
                       @if (audience.detail_des_dommages_et_interets)
-                        {{ audience.detail_des_dommages_et_interets }}
+                        {{{ nl2br(audience.detail_des_dommages_et_interets) }}}
                       @else
                         Oui
                       @endif

--- a/resources/views/pages/audience.edge
+++ b/resources/views/pages/audience.edge
@@ -343,10 +343,14 @@
                   </h4>
                   <p class="mb-0">
                     @if (audience.resume_de_l_audience)
-                      @longParagraphe({ id: 'resume_de_l_audience' })
-                        @slot('text')
-                          {{{ nl2br(audience.resume_de_l_audience) }}}
+                      @if(audience.resume_de_l_audience.length >= 1500)
+                        @longParagraphe({ id: 'resume_de_l_audience' })
+                          @slot('text')
+                            {{{ nl2br(audience.resume_de_l_audience) }}}
+                          @end
                         @end
+                      @else
+                        {{{ nl2br(audience.resume_de_l_audience) }}}
                       @end
                     @else
                       @!emptyData()

--- a/resources/views/pages/home.edge
+++ b/resources/views/pages/home.edge
@@ -157,7 +157,7 @@
                           </h3>
                           <p class="small fw-normal mb-0">
                             @if(audience.faits_concis)
-                              <em>"{{ audience.faits_concis }}"</em>
+                              {{{ nl2br(audience.faits_concis) }}}
                             @else
                               Aucune information
                             @endif
@@ -174,7 +174,7 @@
                           </h3>
                           <p class="small fw-normal mb-0">
                             @if(audience.extrait_de_la_decision)
-                              <em>"{{ audience.extrait_de_la_decision }}"</em>
+                              <em>{{{ nl2br(audience.extrait_de_la_decision) }}}</em>
                             @else
                               Aucune information
                             @endif
@@ -192,7 +192,7 @@
                           </h3>
                           <p class="small fw-normal mb-0">
                             @if(audience.commentaire_msde)
-                              {{ audience.commentaire_msde }}
+                              {{{ nl2br(audience.commentaire_msde) }}}
                             @else
                               Aucune information
                             @endif

--- a/resources/views/pages/home.edge
+++ b/resources/views/pages/home.edge
@@ -43,14 +43,14 @@
             />
           </div>
           <div class="col-3">
-            @!component('components/date_range_picker', {
-            name: 'dateDeLaDecision',
-            label: 'Date de la décision',
-            value: searchQuery.dateDeLaDecision ?? []
+            @!dateRangePicker({
+              name: 'dateDeLaDecision',
+              label: 'Date de la décision',
+              value: searchQuery.dateDeLaDecision ?? []
             })
           </div>
           <div class="col-3">
-            @!component('components/multi_select', {
+            @!multiSelect({
               name: 'chefDePrevention',
               label: 'Chef de prévention',
               options: chefDePreventionCategories.map(c => c.intitule),
@@ -59,7 +59,7 @@
             })
           </div>
           <div class="col-2">
-            @!component('components/more_filters', { searchQuery, villes, juridictions, collectifs })
+            @!moreFilters({ searchQuery, villes, juridictions, collectifs })
           </div>
           <div class="col-1">
             <button class="btn btn-primary" type="submit" style="background-color: #0d6efd; height: 38px;">
@@ -164,7 +164,8 @@
                           </p>
                         </div>
                         <div class="col-lg-7 d-flex justify-content-center justify-content-lg-end align-items-center">
-                          @!component('components/timeline', { data: audience.timeline, current: audience.id, date_des_faits: audience.date_des_faits })
+                          @timeline({ data: audience.timeline, current: audience.id, date_des_faits: audience.date_des_faits })
+                          @end
                         </div>
                       </div>
                       <div class="row bg-gray rounded-3 p-3">


### PR DESCRIPTION
- Ajout d'un composant pour `longParagraphe` pour coller à la maquette sur les résumé d'audience.
- Utilisation de nl2br à plus de text, là où cela me semblé pertinent.
- Petit refacto pour utiliser les tagName plutôt que `@component` pour les composant edge. 