### PR TITLE
fix: truncate timeline tags

### DIFF
--- a/app/controllers/mappers/timeline_mapper.ts
+++ b/app/controllers/mappers/timeline_mapper.ts
@@ -17,6 +17,7 @@ type BaseAudienceItem = {
   id: number
   degre_de_juridiction: string | null
   decision_pour_les_infractions_principales: string | null
+  juridiction: string | null
   type_de_peine_pour_les_infractions_principales: string | null
   skipped_before?: number
   skipped_after?: number

--- a/app/services/audience_service.ts
+++ b/app/services/audience_service.ts
@@ -37,6 +37,7 @@ export type SearchAudiencesResponse = SimplePaginatorContract<
         date_de_decision: DateTime | null
         degre_de_juridiction: string | null
         decision_pour_les_infractions_principales: string | null
+        juridiction: string | null
         type_de_peine_pour_les_infractions_principales: string | null
         publiee: boolean
       }>
@@ -75,6 +76,7 @@ export class AudienceService {
                   'date_de_decision', date_de_decision,
                   'degre_de_juridiction', degre_de_juridiction,
                   'decision_pour_les_infractions_principales', decision_pour_les_infractions_principales,
+                  'juridiction', juridiction,
                   'type_de_peine_pour_les_infractions_principales', type_de_peine_pour_les_infractions_principales,
                   'publiee', publiee
                 )

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -82,26 +82,12 @@
 }
 
 .timeline-node.current > .timeline-pin {
-  background-color: #0d6efd;
-  border-color: #0d6efd;
+  background-color: var(--relx-purple-text);
+  border-color: var(--relx-purple-text);
 }
 
 .timeline-node.current > .label {
-  color: #0d6efd;
-}
-
-.timeline-node > .label.conclusion {
-  background-color: white;
-  border-radius: 4px;
-  padding: 4px;
-}
-
-.timeline-node > .label.acquittal {
-  color: #28a745;
-}
-
-.timeline-node > .label.conviction {
-  color: #dc3545;
+  color: var(--relx-purple-text);
 }
 
 /* Audience page specific styles */

--- a/resources/views/components/timeline.edge
+++ b/resources/views/components/timeline.edge
@@ -35,10 +35,14 @@
           <span class="label mt-1">{{ t.degre_de_juridiction }}</span>
         @end
         @if (t.type_de_peine_pour_les_infractions_principales)
-          <span class="label mt-1 conclusion d-flex align-items-center gap-1 {{ decisionClass }}">
+          <span
+            class="label mt-1 conclusion d-flex align-items-center gap-1 w-100 overflow-hidden {{ decisionClass }}"
+          >
             @svg('ph:gavel-fill', { class:"flex-shrink-0" })
-            {{ t.type_de_peine_pour_les_infractions_principales }}
+            <span class="text-truncate">
+              {{ t.type_de_peine_pour_les_infractions_principales }}
             </span>
+          </span>
         @endif
       @endif
     </div>

--- a/resources/views/components/timeline.edge
+++ b/resources/views/components/timeline.edge
@@ -1,6 +1,6 @@
 @let (dateFormat = 'dd.MM.yy')
 
-<div class="timeline d-flex">
+<div class="timeline d-flex w-100">
   @each((t, index) in data)
     @let(decisionClass = html.classNames({
       'conviction': t.decision_pour_les_infractions_principales === 'Condamnation',
@@ -27,23 +27,25 @@
     >
       <span class="timeline-link"></span>
       <span class="timeline-pin {{ timelinePinClass }}"></span>
-      <span class="label mt-2">{{ t.date === null ? "À venir" : DateTime.fromISO(t.date).toFormat(dateFormat) }}</span>
-      @if (t.type ==='faits')
-        <span class="label mt-1 fw-bold">Faits</span>
-      @else
-        @if (t.degre_de_juridiction)
-          <span class="label mt-1">{{ t.degre_de_juridiction }}</span>
-        @end
-        @if (t.type_de_peine_pour_les_infractions_principales)
-          <span
-            class="label mt-1 conclusion d-flex align-items-center gap-1 w-100 overflow-hidden {{ decisionClass }}"
-          >
-            @svg('ph:gavel-fill', { class:"flex-shrink-0" })
-            <span class="text-truncate">
-              {{ t.type_de_peine_pour_les_infractions_principales }}
+      <span class="d-flex flex-column w-100 overflow-hidden">
+        <span class="label mt-2">{{ t.date === null ? "À venir" : DateTime.fromISO(t.date).toFormat(dateFormat) }}</span>
+        @if (t.type ==='faits')
+          <span class="label mt-1 fw-bold">Faits</span>
+        @else
+          @if (t.juridiction)
+            <span class="label mt-1 text-truncate d-block">{{ t.juridiction }}</span>
+          @end
+          @if (t.type_de_peine_pour_les_infractions_principales)
+            <span
+              class="label mt-1 conclusion d-flex align-items-center gap-1 w-100 overflow-hidden {{ decisionClass }}"
+            >
+              @svg('ph:gavel-fill', { class:"flex-shrink-0" })
+              <span class="text-truncate">
+                {{ t.type_de_peine_pour_les_infractions_principales }}
+              </span>
             </span>
-          </span>
-        @endif
+          @endif
+        </span>
       @endif
     </div>
   @end

--- a/tests/unit/timeline_mapper.spec.ts
+++ b/tests/unit/timeline_mapper.spec.ts
@@ -15,12 +15,14 @@ test.group('Timeline mapper algorithm', () => {
     date_de_decision: DateTime | null = null,
     degre_de_juridiction: string | null = null,
     decision_pour_les_infractions_principales: string | null = null,
+    juridiction: string | null = null,
     type_de_peine_pour_les_infractions_principales: string | null = null
   ): SearchAudiencesResponse[number]['timeline'][number] => ({
     id,
     date_de_decision,
     degre_de_juridiction,
     decision_pour_les_infractions_principales,
+    juridiction,
     type_de_peine_pour_les_infractions_principales,
     publiee: true,
   })


### PR DESCRIPTION
#241 Timeline UI tags

Correction du bug en intégrant la dernière version de la maquette. Le tag tien désormais en une seule ligne tronquée (overflow-hidden + ellipsis). Permet d'afficher la donnée telle que dans la base de donnée. Correction des couleurs et suppression des styles devenus inutiles.

J'ai conservé la logique pour déterminer si c'est une condamnation ou une relaxe : ne connaissant pas les données réelles, est-ce qu'il n'y a que ces deux cas (ou null) ? Est-ce qu'on peut mapper et rendre un texte comme sur la maquette `Relaxe` et `Conda.` uniquement ?

En tous cas, sujet pur front, le problème est réglé.

En parcourant la maquette, j'ai vu que l'étiquette précédente doit afficher la juridiction et non le degré. J'ai remonté l'info depuis le mapper jusqu'au composant front (et màj du test unitaire). Idem : affiche sur une seule ligne tronqué au-delà pour garantir l'UI.

Pour le respect strict de la maquette, on ne devrait pas afficher la valeur de la base brute, mais la mapper (ex: `cassation` => `CCAS`).