### PR TITLE
feat(audience): hidden graph when audience has no chef_de_prevention

### DIFF
--- a/resources/views/pages/audience.edge
+++ b/resources/views/pages/audience.edge
@@ -331,7 +331,7 @@
                 </section>
               </div>
             </div>
-            @if(metabaseToken)
+            @if(metabaseToken && audience.chefs_de_prevention_categorie.length)
               <section class="rounded border p-4" aria-labelledby="graph-evolution-condamnations-heading">
                 <h3 class="small" id="graph-evolution-condamnations-heading">
                   Évolution des condamnations pour ce chef de prévention


### PR DESCRIPTION
Ne pas afficher le graphique dans la page des audiences si l'audience n'a pas de chef de prévention