### PR TITLE
fix: back button keep search context

### DIFF
--- a/app/controllers/audiences_controller.ts
+++ b/app/controllers/audiences_controller.ts
@@ -24,7 +24,7 @@ export default class AudiencesController {
    * @param HttpContext
    * @returns
    */
-  async get({ request, view }: HttpContext) {
+  async get({ request, view, session }: HttpContext) {
     const procedureWithAudiences = await this.procedureService.getProcedureWithAudiencesPubliees(
       request.param('id')
     )
@@ -58,6 +58,7 @@ export default class AudiencesController {
       liensPresse,
       lastDecision,
       metabaseToken,
+      backUrl: session.getIntendedUrl(),
     })
   }
 

--- a/app/controllers/search_audiences_controller.ts
+++ b/app/controllers/search_audiences_controller.ts
@@ -8,7 +8,7 @@ import { TimelineDataMapper } from './mappers/timeline_mapper.ts'
 export default class SearchAudiencesController {
   constructor(public audienceService: AudienceService) {}
 
-  async get({ request, view }: HttpContext) {
+  async get({ request, view, session }: HttpContext) {
     const searchQuery = await request.validateUsing(searchQueryValidator)
 
     const [audiences, villes, collectifs, chefDePreventionCategories, juridictions] =
@@ -24,6 +24,8 @@ export default class SearchAudiencesController {
     for (const audience of audiences) {
       Object.assign(audience, { timeline: timelineDataMapper.map(audience) })
     }
+
+    session.setIntendedUrl(request.url(true))
 
     return view.render('pages/search_audiences', {
       villes,

--- a/resources/views/pages/audience.edge
+++ b/resources/views/pages/audience.edge
@@ -36,7 +36,7 @@
       <div class="container-md px-4 px-md-0 pb-5">
         <section class="hstack flex-wrap gap-2 justify-content-between py-4">
           <a
-            href="{{ urlFor('audiences.search') }}"
+            href="{{ backUrl ?? urlFor('audiences.search') }}"
             class="d-inline-flex align-items-center gap-2 text-bg-accent text-decoration-none"
           >
             @svg('ph:arrow-left-bold', { width: 24, height: 24, class: 'flex-shrink-0' })


### PR DESCRIPTION
Maintenant le bouton Retour sur la page d'une audience permet de revenir sur la page de recherche en gardant le contexte de la dernière de recherche.